### PR TITLE
docs: Python コーディング規約を v1.2 に全面更新

### DIFF
--- a/.claude/skills/py-review/SKILL.md
+++ b/.claude/skills/py-review/SKILL.md
@@ -17,6 +17,11 @@ Python コーディング規約に基づいてコードをレビューする。
 
 ## チェック項目
 
+### ファイルヘッダー
+- [ ] モジュール docstring（triple quotes）が `import` より前にあるか
+- [ ] 目的・関連（Issue番号 / 設計書ID）が記載されているか
+- [ ] 作成者・作成日が記載されているか
+
 ### 命名規則
 - [ ] クラス名が PascalCase か（`EventService`, `QwenTTSClient`）
 - [ ] 関数・変数名が snake_case か
@@ -25,31 +30,48 @@ Python コーディング規約に基づいてコードをレビューする。
 
 ### 型ヒント
 - [ ] 全関数の引数・戻り値に型ヒントがあるか
+- [ ] 戻り値なしの関数に `-> None` があるか
 - [ ] `Optional[X]` より `X | None` を使っているか（Python 3.10+）
-- [ ] `Any` の多用がないか
+- [ ] 括弧と空白が PEP 8 準拠か（型注釈ありは `= 10`、なしは `=10`）
 
 ### 責務分離
-- [ ] `app/core/` が `httpx` / `sqlalchemy` を直接 import していないか
+- [ ] `app/core/` が `httpx` / `sqlalchemy` を direct import していないか
 - [ ] `app/clients/` が DB 操作を行っていないか
 - [ ] `app/api/` が直接ビジネスロジックを持っていないか
 
-### エラーハンドリング
-- [ ] 裸の `except:` がないか（最低でも `except Exception` にする）
-- [ ] 外部 API 呼び出しに timeout が設定されているか
-- [ ] エラーが呼び出し元に伝播しているか（握り潰していないか）
+### コメント・Docstring
+- [ ] Docstring が Google スタイルか（Args / Returns / Raises）
+- [ ] Docstring に型を重複記載していないか（型ヒントに一本化）
+- [ ] コメントが "Why" を書いているか（"What" はコードから読める）
+- [ ] `""" """` をコメント目的で使っていないか（`#` を使う）
+- [ ] 複数処理段階がある関数に処理単位コメントがあるか
 
-### その他
-- [ ] `ruff check` でエラーがないか
-- [ ] docstring / コメントが日本語で書かれているか
-- [ ] 不要な `print()` が残っていないか（`logger.debug()` を使う）
+### エラーハンドリング
+- [ ] 裸の `except:` がないか
+- [ ] 例外を握りつぶしていないか（`logger` 記録 + 再 raise）
+- [ ] 外部 API 呼び出しに `timeout` が設定されているか
+
+### ログ
+- [ ] `print()` が残っていないか（`logger.debug()` を使う）
+- [ ] エラーログに文脈情報（`user_id` 等）が含まれているか
+- [ ] 秘匿情報がログに出力されていないか
+
+### テスト（test_*.py のみ）
+- [ ] テスト名が `test_functionName_expectedBehavior` 形式か
+- [ ] 正常系・異常系の両方があるか
+- [ ] Arrange / Act / Assert 構造になっているか
+- [ ] 外部依存がモック化されているか
 
 ## 出力形式
 
 ```
+[ヘッダー] モジュール docstring がない → 追加必要
 [命名] QwenTtsClient → QwenTTSClient に修正
-[型ヒント] synthesize() の戻り値型がない → 追加必要
+[型ヒント] synthesize() に -> None がない → 追加必要
 [責務] app/core/planning.py が httpx を import → clients/ に移動
+[Docstring] fetch_user() に Args: がない → 追加必要
 [エラー] except: が裸 → except Exception as e: に修正
+[テスト] 異常系テストなし → 追加必要
 ```
 
 詳細: [コーディング規約](../../../docs/03_standards/python_coding_standard.md)

--- a/.codex/skills/py-review/SKILL.md
+++ b/.codex/skills/py-review/SKILL.md
@@ -17,37 +17,51 @@ Python コーディング規約に基づいてコードをレビューする。
 
 ## チェック項目
 
+### ファイルヘッダー
+- [ ] モジュール docstring（triple quotes）が `import` より前にあるか
+- [ ] 目的・関連（Issue番号 / 設計書ID）が記載されているか
+- [ ] 作成者・作成日が記載されているか
+
 ### 命名規則
-- [ ] クラス名が PascalCase か（`EventService`, `QwenTTSClient`）
+- [ ] クラス名が PascalCase か
 - [ ] 関数・変数名が snake_case か
 - [ ] 定数が UPPER_SNAKE_CASE か
 
 ### 型ヒント
 - [ ] 全関数の引数・戻り値に型ヒントがあるか
-- [ ] `Optional[X]` より `X | None` を使っているか（Python 3.10+）
+- [ ] 戻り値なしの関数に `-> None` があるか
+- [ ] `Optional[X]` より `X | None` を使っているか
+- [ ] 括弧と空白が PEP 8 準拠か
 
 ### 責務分離
 - [ ] `app/core/` が `httpx` / `sqlalchemy` を import していないか
 - [ ] `app/clients/` が DB 操作を行っていないか
-- [ ] `app/api/` が直接ビジネスロジックを持っていないか
+
+### コメント・Docstring
+- [ ] Docstring が Google スタイルか（Args / Returns / Raises）
+- [ ] Docstring に型を重複記載していないか
+- [ ] コメントが "Why" を書いているか
+- [ ] `""" """` をコメント目的で使っていないか
 
 ### エラーハンドリング
 - [ ] 裸の `except:` がないか
-- [ ] 外部 API 呼び出しに timeout が設定されているか
-- [ ] エラーが呼び出し元に伝播しているか
+- [ ] 例外を握りつぶしていないか
+- [ ] 外部 API 呼び出しに `timeout` が設定されているか
 
-### その他
-- [ ] `ruff check` でエラーがないか
-- [ ] コメントが日本語で書かれているか
-- [ ] 不要な `print()` が残っていないか
+### テスト（test_*.py のみ）
+- [ ] テスト名が `test_functionName_expectedBehavior` 形式か
+- [ ] 正常系・異常系の両方があるか
+- [ ] Arrange / Act / Assert 構造になっているか
 
 ## 出力形式
 
 ```
+[ヘッダー] モジュール docstring がない → 追加必要
 [命名] QwenTtsClient → QwenTTSClient に修正
-[型ヒント] synthesize() の戻り値型がない → 追加必要
-[責務] app/core/planning.py が httpx を import → clients/ に移動
-[エラー] except: が裸 → except Exception as e: に修正
+[型ヒント] synthesize() に -> None がない → 追加必要
+[Docstring] fetch_user() に Args: がない → 追加必要
+[エラー] except: が裸 → 修正必要
+[テスト] 異常系テストなし → 追加必要
 ```
 
 詳細: `docs/03_standards/python_coding_standard.md`

--- a/docs/03_standards/python_coding_standard.md
+++ b/docs/03_standards/python_coding_standard.md
@@ -1,45 +1,183 @@
 # Python コーディング規約 — aituber
 
-## 1. 基本方針
+**Version:** 1.2
+**作成日:** 2025-12-25
+**最終更新:** 2026-02-17
+**作成者:** 宗廣 颯真
+**対象:** Python による開発全般（Web / バッチ / スクリプト）
 
-- Python 3.11+ を前提とする
-- 型ヒントを全関数に付ける（`mypy --strict` レベルを目標）
-- コメント・docstring は **日本語** で書く
-- フォーマッタ・リンタは `ruff` を使用（pre-commit で自動適用）
+## このページが扱う内容
+
+このページでは **Python におけるコードの書き方（コーディング規約）** のみを扱う。
+レビュー手順、環境構築、AI レビュー活用、運用ルールなどは別ページで取り扱う。
+
+含まれる情報: コードスタイル / 命名規則 / 型ヒント / クラス・関数の設計方針 /
+コメント・Docstring / エラーハンドリング / ログ / セキュリティ / テスト / 禁止事項 / pyproject.toml 設定
 
 ---
 
-## 2. 命名規則
+## 設計書との整合性
+
+- コードと設計書は常に相互参照可能（双方向）であること
+- 設計書に登場する用語・機能名・概念名をモジュール名 / クラス名 / 関数名へ反映する
+- 設計変更が入った場合、コードと設計書の差分を放置しない（差分が出るならチケット化する）
+
+---
+
+## コーディング時の基本ルール
+
+- スタイル統一のため Linter（ruff）を使用
+- コード整形のため black を使用（`line-length = 120`）
+- import 整形に ruff を使用
+- 型品質向上のため mypy を推奨（`strict = true`）
+
+---
+
+## ディレクトリ構造
+
+```
+aituber/
+  ├─ app/
+  │   ├─ api/           # REST API ルーター（HTTP のみ）
+  │   ├─ core/          # ドメインロジック（外部依存禁止）
+  │   ├─ models/        # SQLAlchemy モデル + Pydantic スキーマ
+  │   ├─ clients/       # 外部 API クライアント（LLM / TTS）
+  │   ├─ db/            # DB セッション・Alembic 設定
+  │   ├─ config/        # pydantic-settings による設定読み込み
+  │   └─ utils/         # ログ・ファイル操作ユーティリティ
+  ├─ tests/
+  ├─ pyproject.toml
+  └─ .env.example
+```
+
+---
+
+## Python ファイルのヘッダー
+
+### 目的
+
+ファイルの責務・背景・設計書との対応をソース先頭だけで把握できるようにする。
+
+### 適用範囲
+
+- `app/` 配下のアプリコード（特に core・api・clients）
+- `tests/` は任意（必要性がある場合のみ）
+- 自動生成コードは対象外
+
+### テンプレート（推奨）
+
+```python
+"""
+<ファイルの概要を1行で>（例：実況生成サービスの実装）
+
+- 目的: <このファイルの責務 / 何を提供するか>
+- 対象: <主な利用者（例：API層 / バッチ / CLI）>
+- 関連: <設計書ID / チケットID / Issue番号など>
+
+作成者: 宗廣 颯真
+作成日: YYYY-MM-DD
+最終更新者: 宗廣 颯真
+最終更新日: YYYY-MM-DD
+"""
+```
+
+### 記入例
+
+```python
+"""
+実況生成サービスの実装。
+
+- 目的: 発話計画を受け取り LLM に送信して実況テキストを生成する
+- 対象: api/commentaries.py
+- 関連: Issue #9, docs/02_design/system_design.md
+
+作成者: 宗廣 颯真
+作成日: 2026-04-22
+最終更新者: 宗廣 颯真
+最終更新日: 2026-04-22
+"""
+```
+
+---
+
+## コードスタイル
+
+- インデント: スペース 4（タブ禁止）
+- 行の長さ: 120 文字以内（black / ruff で統一）
+- 文字コード: UTF-8
+- import の順序: 標準ライブラリ → サードパーティ → アプリ内部
+
+---
+
+## 命名規則
 
 | 対象 | 規則 | 例 |
 |---|---|---|
+| 変数 | snake_case | `user_name`, `segment_id` |
+| 関数・メソッド | snake_case | `fetch_user`, `generate_event` |
 | クラス | PascalCase | `EventService`, `QwenTTSClient` |
-| 関数・メソッド | snake_case | `generate_event`, `synthesize` |
-| 変数 | snake_case | `segment_id`, `audio_path` |
-| 定数 | UPPER_SNAKE_CASE | `DEFAULT_SEGMENT_DURATION` |
+| 定数 | UPPER_SNAKE_CASE | `DEFAULT_TIMEOUT`, `MAX_RETRY` |
+| ファイル名 | snake_case | `event_generation.py` |
 | プライベート | 先頭に `_` | `_build_prompt` |
-| モジュール | snake_case | `event_generation.py` |
 
 ---
 
-## 3. 型ヒント
+## 型ヒント
+
+### すべての関数に型を明記する
 
 ```python
-# 良い例
-def generate(self, segment_id: str) -> list[Event]:
+def fetch_user(user_id: int) -> User:
     ...
 
-# 悪い例（型ヒントなし）
-def generate(self, segment_id):
+def update_last_login(user_id: int) -> None:
     ...
 ```
 
-- `Optional[X]` の代わりに `X | None` を使う（Python 3.10+）
+### Union は `|` 記法（Python 3.10+）
+
+```python
+def load(data: str | None) -> str:
+    ...
+```
+
+- `Optional[X]` の代わりに `X | None` を使う
 - `Any` の多用は避ける。使う場合はコメントで理由を記載
+
+### 括弧と空白の規則（PEP 8）
+
+```python
+# 良い例
+def fetch_user(user_id: int) -> User:
+    ...
+fetch_user(user_id=1)
+
+# NG: 関数名と ( の間に空白
+def fetch_user (user_id: int) -> User:
+
+# NG: ( の直後 / ) の直前に空白
+f( x, y )
+
+# 型注釈あり: = の前後に空白
+def f(limit: int = 10) -> None: ...
+
+# 型注釈なし: = の前後に空白なし
+def f(limit=10): ...
+
+# キーワード引数: = の前後に空白なし
+fetch_user(user_id=1, include_profile=True)
+```
 
 ---
 
-## 4. 責務分離ルール
+## クラスと関数の設計
+
+- 関数の責務は「単一」にする
+- ネスト（if / for）は 3 段以内
+- 複雑な処理は private メソッドに分離
+- 過度な抽象化は禁止（必要以上のクラス化・共通化を避ける）
+
+### 責務分離ルール（aituber 固有）
 
 | パッケージ | 責務 | 禁止事項 |
 |---|---|---|
@@ -53,12 +191,98 @@ def generate(self, segment_id):
 
 ---
 
-## 5. エラーハンドリング
+## コメントと Docstring
+
+### 基本方針
+
+- コメントは "What（何をしているか）" ではなく "Why（なぜそうするか）" を書く
+- 処理単位の説明コメントを適切に挿入し、読み手が処理の塊を追えるようにする
+- Docstring は Sphinx による設計書生成を前提に **Google スタイル**で統一する
+
+### 処理単位コメントの規則
+
+1 つの関数内で複数の処理段階がある場合、処理ブロックの前に処理単位コメントを記載する。
 
 ```python
-# 良い例
+def create_user_profile(user_input: dict) -> User:
+    # 入力検証（欠損・型・業務ルール）
+    ...
+
+    # 既存ユーザー重複チェック
+    ...
+
+    # 永続化（リポジトリへ保存）
+    ...
+
+    # 応答モデル組み立て
+    ...
+```
+
+### 行コメントの使い分け
+
+- `""" ... """` は Docstring 用途に限定し、コメント目的では使用しない
+- コメントは原則「対象コードの直前」に書く（行末コメントは最小限）
+
+```python
+# NG: Docstring をコメント目的で使う
+def f() -> None:
+    """
+    これはコメントのつもり（NG）
+    """
+    ...
+
+# OK: lint 抑止など例外的な行末コメント
+payload: dict[str, Any] = load_payload()  # noqa: ANN401（外部I/FのためAnyを許容）
+```
+
+### Docstring 形式（Google スタイル）
+
+```python
+def fetch_user(user_id: int) -> User:
+    """ユーザーIDを指定してユーザー情報を取得する。
+
+    Args:
+        user_id: 対象ユーザーID。正の整数であること。
+
+    Returns:
+        ユーザーエンティティ。
+
+    Raises:
+        UserNotFound: 指定したIDのユーザーが存在しない場合。
+        ValueError: user_id が正の整数でない場合。
+    """
+    ...
+```
+
+- 1行目：80文字以内で何をするかを簡潔に記述
+- 型は型ヒントに一本化し、Docstring に重複記載しない
+- `dict[str, Any]` 等で型が抽象的な場合は期待するキー・構造を記載する
+- セクション順序: `Args:` → `Returns:` → `Raises:` → `Examples:`
+
+---
+
+## エラーハンドリング
+
+### 禁止
+
+- 空の `except:`
+- `except Exception:` の乱用
+- ログを書かずに例外を無視する行為
+
+### 推奨
+
+```python
 try:
-    response = await client.post(url, json=payload)
+    user = repo.get(id)
+except UserNotFound:
+    logger.warning("User not found", user_id=id)
+    raise
+```
+
+```python
+# 外部 API 呼び出し（必ず timeout 設定）
+try:
+    response = await client.post(url, json=payload, timeout=10.0)
     response.raise_for_status()
 except httpx.TimeoutException:
     logger.error("TTS API タイムアウト: url=%s", url)
@@ -66,76 +290,221 @@ except httpx.TimeoutException:
 except httpx.HTTPStatusError as e:
     logger.error("TTS API エラー: status=%d", e.response.status_code)
     raise
-
-# 悪い例（握り潰し）
-try:
-    response = await client.post(url, json=payload)
-except Exception:
-    pass
 ```
-
-- 裸の `except:` は禁止
-- エラーは必ず `logger` に記録してから再 raise する
-- 外部 API 呼び出しには必ず `timeout` を設定する
 
 ---
 
-## 6. ログ
+## ログ出力
+
+- JSON 形式を推奨
+- `user_id` / `trace_id` など文脈情報を含める
+- `print` デバッグは禁止。`logging` または `structlog` を使用
 
 ```python
 from app.utils.logging import logger
 
-# 使い方
 logger.info("セグメント分割開始: video_id=%s", video_id)
 logger.debug("VLM レスポンス: %s", response)
 logger.error("TTS 生成失敗: segment_id=%s", segment_id, exc_info=True)
 ```
 
-- `print()` は使わない。`logger.debug()` を使う
-- 本番環境で不要な詳細（プロンプト全文等）は `logger.debug()` にする
-- 秘匿情報（API キー等）はログに出力しない
+---
+
+## セキュリティ
+
+- `eval` / `exec` 禁止
+- Secrets（API キー / パスワード等）の直書き禁止（`.env` 経由で管理）
+- `requests` / `httpx` は `timeout` を必須設定
+- SQL は ORM または安全なプレースホルダを使用
 
 ---
 
-## 7. 設定値
+## テスト
 
-```python
-# 良い例：設定は app/config/config.py 経由
-from app.config.config import settings
-duration = settings.segment_duration
+### 命名規則
 
-# 悪い例：ハードコード
-duration = 5
+```
+test_functionName_expectedBehavior
 ```
 
-- マジックナンバーは `settings` または定数化する
-
----
-
-## 8. コメント・docstring
+規約に従い `camelCase` の関数名部分を維持する（アンダースコア区切りではなく）:
 
 ```python
-def plan_for_segment(self, segment_id: str) -> list[UtterancePlan]:
-    """指定セグメントのイベントから発話計画を生成する。"""
-    # 連続発話抑制: 直前発話から EVENT_GROUPING_WINDOW 秒以内はスキップ
+def test_fetchUser_returns_user_when_exists():
+    ...
+
+def test_fetchUser_raises_UserNotFound_when_missing():
+    ...
+
+def test_generateEvent_returns_default_when_vlm_empty():
     ...
 ```
 
-- docstring は公開メソッドに付ける（1 行で済む場合は 1 行）
-- コメントは「なぜ」を書く。「何をしているか」はコードから読める
+### 基本方針
+
+- 正常系・異常系を両方作成する
+- Mock は必要最低限で使用する
+- 外部依存（DB・外部 API）は `pytest-mock` でモック化する
+- テストは `tests/` 配下に `test_<module>.py` で作成する
+
+### pytest 設定
+
+```toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-v"
+```
+
+### conftest.py の活用
+
+共通フィクスチャは `tests/conftest.py` に集約する。
+
+```python
+# tests/conftest.py
+import pytest
+from unittest.mock import MagicMock
+
+@pytest.fixture
+def mock_llm_client():
+    client = MagicMock()
+    client.complete.return_value = "実況テキストのサンプル"
+    return client
+
+@pytest.fixture
+def mock_tts_client():
+    client = MagicMock()
+    client.synthesize.return_value = ("/var/media/audio.wav", 2.4)
+    return client
+```
+
+### テストの構造（Arrange / Act / Assert）
+
+```python
+def test_generateEvent_returns_event_when_normal_scene(mock_vision_service):
+    # Arrange（準備）
+    service = EventService(vision=mock_vision_service)
+    mock_vision_service.analyze_frame.return_value = {
+        "scene_summary": "戦闘中",
+        "objects": ["敵", "プレイヤー"],
+        "confidence": 0.8,
+    }
+
+    # Act（実行）
+    events = service.generate(segment_id="seg-001")
+
+    # Assert（検証）
+    assert len(events) >= 1
+    assert events[0].speak_recommended is True
+```
 
 ---
 
-## 9. テスト
+## 禁止事項
 
-- テストは `tests/` 配下に `test_<module>.py` で作成
-- 外部依存（DB・外部 API）は `pytest-mock` でモック化
-- テスト関数名: `test_<対象>_<条件>_<期待結果>`
+- 未使用変数・未使用 import
+- マジックナンバー
+- `print` デバッグ
+- コメントとコードの不一致
+- 例外の握りつぶし
+- 過度な if-else ネスト
+- グローバル変数の乱用
+
+---
+
+## サンプルコード（規約適用例）
 
 ```python
-def test_generate_event_normal_scene_returns_event():
-    ...
+"""
+実況生成サービスの実装。
 
-def test_generate_event_empty_vlm_output_returns_default_event():
-    ...
+- 目的: 発話計画を受け取り LLM に送信して実況テキストを生成する
+- 対象: api/commentaries.py
+- 関連: Issue #9
+
+作成者: 宗廣 颯真
+作成日: 2026-04-22
+最終更新者: 宗廣 颯真
+最終更新日: 2026-04-22
+"""
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UtterancePlan:
+    plan_id: str
+    event_summary: str
+    style: str
+
+
+class LLMClientError(Exception):
+    pass
+
+
+def generate_commentary(plan: UtterancePlan, llm_client) -> str:
+    """発話計画をもとに実況テキストを生成する。
+
+    Args:
+        plan: 発話計画。event_summary と style を含む。
+        llm_client: LLM API クライアント。
+
+    Returns:
+        生成された実況テキスト（1〜2文）。
+
+    Raises:
+        LLMClientError: LLM API の呼び出しに失敗した場合。
+    """
+
+    # プロンプト構築（スタイルに応じたシステム指示を含める）
+    prompt = _build_prompt(plan)
+
+    # LLM 呼び出し
+    try:
+        text = llm_client.complete(prompt)
+    except Exception as e:
+        logger.error("LLM 呼び出し失敗: plan_id=%s", plan.plan_id, exc_info=True)
+        raise LLMClientError("LLM 呼び出しに失敗しました") from e
+
+    # 返却（1〜2文に収まるか検証）
+    return text.strip()
+
+
+def _build_prompt(plan: UtterancePlan) -> str:
+    """発話計画からLLM向けプロンプトを構築する。"""
+    return f"スタイル: {plan.style}\nイベント: {plan.event_summary}\n1〜2文で実況してください。"
+```
+
+---
+
+## 付録：pyproject.toml 設定例
+
+```toml
+[tool.black]
+line-length = 120
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+ignore_missing_imports = true
+strict = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-v"
 ```


### PR DESCRIPTION
## 概要

ユーザー提供の Python コーディング規約 v1.2 をプロジェクト規約として反映。

## 主な変更

- **ファイルヘッダー**: 全 `app/` ファイルにモジュール docstring テンプレートを義務化
- **Docstring**: Google スタイルに統一（Args / Returns / Raises）
- **テスト命名**: `test_functionName_expectedBehavior` 形式に統一
- **conftest.py**: 共通フィクスチャパターンのサンプルを追加
- **AAA 構造**: Arrange / Act / Assert コメントによるテスト構造を明示化
- **括弧・空白**: PEP 8 に沿った詳細規則（型注釈あり/なしの `=` 空白等）を追記
- **py-review スキル**: `.claude/` と `.codex/` 両方を新規約チェック項目に対応

## 合わせて対応

- `enforce_admins=true` をブランチ保護に設定済み（このPRはその後初のPR経由マージ）