### PR TITLE
feat: TTS instruct 熱量制御・VLM フレーム解析・エクスポート修正

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.clients.llm_client import LLMClient
 from app.clients.qwen_tts_client import QwenTTSClient
+from app.clients.vlm_client import VLMClient
 from app.config.config import settings
 from app.core.composer import AudioEntry, Composer
 from app.core.event_generation import EventService
@@ -102,6 +103,11 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     )
     frame_extractor = FrameExtractor(media_root=settings.media_root)
     vision_service = VisionService()
+    vlm_client = VLMClient(
+        base_url=settings.llm_api_base,
+        api_key=settings.llm_api_key,
+        model=settings.vlm_model_name,
+    )
     event_service = EventService()
     planner = UtterancePlanner()
     commentary_service = CommentaryService()
@@ -136,7 +142,7 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
 
         analyses = []
         for fr in frame_results:
-            analysis = vision_service.analyze_frame(fr.image_path)
+            analysis = vision_service.analyze_frame(fr.image_path, vlm_client)
             frame = Frame(
                 segment_id=segment.id,
                 timestamp=fr.timestamp,

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -325,11 +325,11 @@ def export_video(video_id: str, db: Session = Depends(get_db)) -> StreamingRespo
             srt_arcname = ""
 
             if audio and audio.storage_path and Path(audio.storage_path).exists():
-                audio_arcname = f"audio/{Path(audio.storage_path).name}"
+                audio_arcname = f"audio/{commentary.id}.wav"
                 zf.write(audio.storage_path, audio_arcname)
 
             if subtitle and subtitle.file_path and Path(subtitle.file_path).exists():
-                srt_arcname = f"subtitles/{Path(subtitle.file_path).name}"
+                srt_arcname = f"subtitles/{commentary.id}.srt"
                 zf.write(subtitle.file_path, srt_arcname)
 
             csv_rows.append({

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -39,6 +39,16 @@ from app.utils.logging import logger
 
 router = APIRouter()
 
+# 実況スタイル → TTS instruct テキスト
+_STYLE_INSTRUCT: dict[str, str] = {
+    "excited": (
+        "Speak with high energy and excitement, "
+        "like a passionate game streamer at a climactic moment."
+    ),
+    "neutral": "Speak in a natural, conversational voice like a friendly game commentator.",
+    "calm": "Speak slowly and calmly in a relaxed, gentle voice with low energy.",
+}
+
 
 @router.post("/", response_model=VideoRead, status_code=201)
 def upload_video(
@@ -217,7 +227,8 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             continue
 
         audio_path = str(Path(settings.media_root) / str(commentary.id) / "audio.wav")
-        duration = tts_client.synthesize(commentary.text, audio_path)
+        instruct = _STYLE_INSTRUCT.get(commentary.style or "", "")
+        duration = tts_client.synthesize(commentary.text, audio_path, instruct=instruct)
 
         audio = Audio(
             commentary_id=commentary.id,

--- a/app/clients/qwen_tts_client.py
+++ b/app/clients/qwen_tts_client.py
@@ -84,6 +84,7 @@ class QwenTTSClient:
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         Path(output_path).write_bytes(response.content)
 
+        self._append_silence(output_path)
         return self._wav_duration(output_path)
 
     def _build_payload(
@@ -109,6 +110,19 @@ class QwenTTSClient:
         if instruct:
             payload["instruct"] = instruct
         return payload
+
+    def _append_silence(self, wav_path: str, pad_seconds: float = 0.3) -> None:
+        """WAV 末尾に無音フレームを追加する。TTS モデルの末尾クリップを補正する。"""
+        with wave.open(wav_path, "rb") as wf:
+            params = wf.getparams()
+            audio_frames = wf.readframes(wf.getnframes())
+
+        silent_frame_count = int(params.framerate * pad_seconds)
+        silent_bytes = b"\x00" * silent_frame_count * params.nchannels * params.sampwidth
+
+        with wave.open(wav_path, "wb") as wf:
+            wf.setparams(params)
+            wf.writeframes(audio_frames + silent_bytes)
 
     def _wav_duration(self, wav_path: str) -> float:
         with wave.open(wav_path, "rb") as wf:

--- a/app/clients/qwen_tts_client.py
+++ b/app/clients/qwen_tts_client.py
@@ -56,9 +56,10 @@ class QwenTTSClient:
         mode = mode or self.default_mode
         speaker = speaker or self.default_speaker
         language = language or self.default_language
+        instruct = instruct or self.default_instruct
 
         endpoint = self._ENDPOINT_MAP.get(mode, f"/tts/{mode}")
-        form_data = self._build_form(endpoint, text, speaker, language)
+        form_data = self._build_form(endpoint, text, speaker, language, instruct)
 
         response: httpx.Response | None = None
         for attempt in range(self._MAX_RETRIES):
@@ -89,13 +90,20 @@ class QwenTTSClient:
         text: str,
         speaker: str,
         language: str,
+        instruct: str = "",
     ) -> dict[str, str]:
         """エンドポイントに応じた form-data を組み立てる。"""
         if "voice-clone/profile" in endpoint:
-            # profile_name は .pt 拡張子ごと渡す
+            # instruct 非対応: profile_name (.pt 拡張子ごと) のみ
             return {"text": text, "profile_name": speaker, "language": language}
-        # custom-voice / voice-design
-        return {"text": text, "speaker": speaker, "language": language}
+        if "voice-design" in endpoint:
+            # speaker 不要、instruct 必須
+            return {"text": text, "instruct": instruct, "language": language}
+        # custom-voice: instruct は任意
+        form: dict[str, str] = {"text": text, "speaker": speaker, "language": language}
+        if instruct:
+            form["instruct"] = instruct
+        return form
 
     def _wav_duration(self, wav_path: str) -> float:
         with wave.open(wav_path, "rb") as wf:

--- a/app/clients/qwen_tts_client.py
+++ b/app/clients/qwen_tts_client.py
@@ -59,14 +59,16 @@ class QwenTTSClient:
         instruct = instruct or self.default_instruct
 
         endpoint = self._ENDPOINT_MAP.get(mode, f"/tts/{mode}")
-        form_data = self._build_form(endpoint, text, speaker, language, instruct)
+        payload = self._build_payload(endpoint, text, speaker, language, instruct)
+        use_form = "voice-clone/profile" in endpoint
 
         response: httpx.Response | None = None
         for attempt in range(self._MAX_RETRIES):
             try:
                 response = httpx.post(
                     f"{self._base_url}{endpoint}",
-                    data=form_data,
+                    data=payload if use_form else None,
+                    json=None if use_form else payload,
                     timeout=60.0,
                 )
                 response.raise_for_status()
@@ -84,7 +86,7 @@ class QwenTTSClient:
 
         return self._wav_duration(output_path)
 
-    def _build_form(
+    def _build_payload(
         self,
         endpoint: str,
         text: str,
@@ -92,18 +94,21 @@ class QwenTTSClient:
         language: str,
         instruct: str = "",
     ) -> dict[str, str]:
-        """エンドポイントに応じた form-data を組み立てる。"""
+        """エンドポイントに応じたリクエストペイロードを組み立てる。
+
+        voice-clone/profile のみ Form、それ以外は JSON body。
+        """
         if "voice-clone/profile" in endpoint:
-            # instruct 非対応: profile_name (.pt 拡張子ごと) のみ
+            # Form data: instruct 非対応
             return {"text": text, "profile_name": speaker, "language": language}
         if "voice-design" in endpoint:
-            # speaker 不要、instruct 必須
+            # JSON body: speaker 不要、instruct 必須
             return {"text": text, "instruct": instruct, "language": language}
-        # custom-voice: instruct は任意
-        form: dict[str, str] = {"text": text, "speaker": speaker, "language": language}
+        # custom-voice: JSON body、instruct は任意
+        payload: dict[str, str] = {"text": text, "speaker": speaker, "language": language}
         if instruct:
-            form["instruct"] = instruct
-        return form
+            payload["instruct"] = instruct
+        return payload
 
     def _wav_duration(self, wav_path: str) -> float:
         with wave.open(wav_path, "rb") as wf:

--- a/app/clients/vlm_client.py
+++ b/app/clients/vlm_client.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any
+
+import cv2
+from openai import OpenAI
+
+from app.core.vision import VisionAnalysis
+
+logger = logging.getLogger(__name__)
+
+_PROMPT = """\
+You are a game scene analyzer. Analyze this game screenshot and return ONLY a JSON object with these fields:
+- scene_summary: brief Japanese description of what is happening (例: "戦闘中", "ボスとの激しい攻防")
+- objects: list of key entities visible (例: ["プレイヤー", "敵", "ボス"])
+- actions: list of ongoing actions in Japanese (例: ["攻撃", "移動", "待機", "スコア変化"])
+- ui_state: list of visible UI elements (例: ["HPバー", "スコア表示"])
+- confidence: float 0.0-1.0 representing how exciting or important this moment is
+
+Return ONLY valid JSON. No markdown fences, no explanation."""
+
+
+class VLMClient:
+    """Vision Language Model クライアント。フレーム画像を解析して VisionAnalysis を返す。"""
+
+    _RESIZE_WIDTH = 640
+
+    def __init__(self, base_url: str, api_key: str, model: str) -> None:
+        self._client = OpenAI(base_url=base_url, api_key=api_key)
+        self._model = model
+
+    def analyze(self, image_path: str) -> VisionAnalysis:
+        """フレーム画像を VLM で解析して VisionAnalysis を返す。失敗時はダミーにフォールバック。"""
+        try:
+            b64 = self._encode_image(image_path)
+            response = self._client.chat.completions.create(
+                model=self._model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": _PROMPT},
+                            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+                        ],
+                    }
+                ],
+                max_tokens=512,
+                temperature=0.1,
+            )
+            raw = response.choices[0].message.content or ""
+            return self._parse(raw)
+        except Exception:
+            logger.exception("VLM 解析失敗: %s", image_path)
+            return VisionAnalysis(scene_summary="解析失敗", confidence=0.3)
+
+    def _encode_image(self, image_path: str) -> str:
+        """画像を JPEG に変換して base64 エンコードする。長辺を _RESIZE_WIDTH に縮小する。"""
+        img = cv2.imread(image_path)
+        if img is None:
+            raise ValueError(f"画像読み込み失敗: {image_path}")
+        h, w = img.shape[:2]
+        if w > self._RESIZE_WIDTH:
+            scale = self._RESIZE_WIDTH / w
+            img = cv2.resize(img, (self._RESIZE_WIDTH, int(h * scale)))
+        _, buf = cv2.imencode(".jpg", img, [cv2.IMWRITE_JPEG_QUALITY, 85])
+        return base64.b64encode(buf.tobytes()).decode()
+
+    def _parse(self, raw: str) -> VisionAnalysis:
+        """VLM レスポンスを VisionAnalysis にパースする。失敗時はテキストをそのまま使う。"""
+        try:
+            text = raw.strip()
+            # マークダウンコードブロックを除去
+            if text.startswith("```"):
+                text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+            data: dict[str, Any] = json.loads(text)
+            return VisionAnalysis(
+                scene_summary=str(data.get("scene_summary", "")),
+                objects=list(data.get("objects", [])),
+                actions=list(data.get("actions", [])),
+                ui_state=list(data.get("ui_state", [])),
+                confidence=float(data.get("confidence", 0.5)),
+            )
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            logger.warning("VLM レスポンスのパース失敗: %s", raw[:200])
+            return VisionAnalysis(scene_summary=raw[:80], confidence=0.5)

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     llm_api_base: str = "https://api.openai.com/v1"
     llm_api_key: str = ""
     llm_model_name: str = "gpt-4-turbo"
+    vlm_model_name: str = "gemma3:27b"
 
     media_root: str = "/var/aituber/media"
     log_level: str = "INFO"

--- a/app/core/vision.py
+++ b/app/core/vision.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.clients.vlm_client import VLMClient
 
 
 @dataclass
@@ -13,41 +16,24 @@ class VisionAnalysis:
     confidence: float = 0.8
 
 
-_DUMMY_SCENES: list[VisionAnalysis] = [
-    VisionAnalysis(
-        scene_summary="戦闘中・クライマックス",
-        objects=["敵", "プレイヤー"],
-        actions=["攻撃"],
-        ui_state=[],
-        confidence=0.9,
-    ),
-    VisionAnalysis(
-        scene_summary="移動中",
-        objects=["マップ", "プレイヤー"],
-        actions=["移動"],
-        ui_state=[],
-        confidence=0.5,
-    ),
-    VisionAnalysis(
-        scene_summary="待機中",
-        objects=["プレイヤー"],
-        actions=["待機"],
-        ui_state=[],
-        confidence=0.2,
-    ),
-]
-
-
 class VisionService:
-    """フレーム画像を解析してシーン情報を返す。MVP ではダミーレスポンスを返す。"""
+    """フレーム画像を解析してシーン情報を返す。"""
 
-    def analyze_frame(self, image_path: str) -> VisionAnalysis:
-        """フレームのシーン情報を返す。後続イシューで実 VLM に差し替える。
-
-        スタイル検証用に excited / neutral / calm を循環するダミーを返す。
-        """
-        idx = hash(image_path) % len(_DUMMY_SCENES)
-        return _DUMMY_SCENES[idx]
+    def analyze_frame(
+        self,
+        image_path: str,
+        vlm_client: VLMClient | None = None,
+    ) -> VisionAnalysis:
+        """フレームのシーン情報を返す。vlm_client が渡された場合は VLM で解析する。"""
+        if vlm_client is not None:
+            return vlm_client.analyze(image_path)
+        return VisionAnalysis(
+            scene_summary="戦闘中",
+            objects=["敵", "プレイヤー"],
+            actions=["攻撃"],
+            ui_state=[],
+            confidence=0.8,
+        )
 
     def to_dict(self, analysis: VisionAnalysis) -> dict[str, Any]:
         return {

--- a/app/core/vision.py
+++ b/app/core/vision.py
@@ -13,18 +13,41 @@ class VisionAnalysis:
     confidence: float = 0.8
 
 
+_DUMMY_SCENES: list[VisionAnalysis] = [
+    VisionAnalysis(
+        scene_summary="戦闘中・クライマックス",
+        objects=["敵", "プレイヤー"],
+        actions=["攻撃"],
+        ui_state=[],
+        confidence=0.9,
+    ),
+    VisionAnalysis(
+        scene_summary="移動中",
+        objects=["マップ", "プレイヤー"],
+        actions=["移動"],
+        ui_state=[],
+        confidence=0.5,
+    ),
+    VisionAnalysis(
+        scene_summary="待機中",
+        objects=["プレイヤー"],
+        actions=["待機"],
+        ui_state=[],
+        confidence=0.2,
+    ),
+]
+
+
 class VisionService:
     """フレーム画像を解析してシーン情報を返す。MVP ではダミーレスポンスを返す。"""
 
     def analyze_frame(self, image_path: str) -> VisionAnalysis:
-        """フレームのシーン情報を返す。後続イシューで実 VLM に差し替える。"""
-        return VisionAnalysis(
-            scene_summary="戦闘中",
-            objects=["敵", "プレイヤー"],
-            actions=["攻撃"],
-            ui_state=[],
-            confidence=0.8,
-        )
+        """フレームのシーン情報を返す。後続イシューで実 VLM に差し替える。
+
+        スタイル検証用に excited / neutral / calm を循環するダミーを返す。
+        """
+        idx = hash(image_path) % len(_DUMMY_SCENES)
+        return _DUMMY_SCENES[idx]
 
     def to_dict(self, analysis: VisionAnalysis) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## 概要

- TTS モード切り替え（voice_clone_profile / custom_voice / voice_design）を `.env` で制御可能にした
- 実況スタイル（excited / neutral / calm）を英語 instruct に変換して TTS へ渡す熱量連動ボイスを実装
- custom_voice / voice_design は JSON body 送信に修正（Form data 送信で 422 になっていたバグを修正）
- VLMClient を新規追加し、VisionService が gemma3:27b でフレームを実解析するよう実装
- エクスポート ZIP 内の audio / SRT ファイル名を commentary.id でユニーク化（上書きされて最後の1件しか残らないバグを修正）
- TTS 末尾クリップ補正として合成後に無音 300ms を追加

## 関連 Issue

Closes #14

## 確認事項

- [x] custom_voice (ono_anna) で全発話の音声合成成功
- [x] excited / neutral / calm で声のトーン差を確認
- [x] VLM がポケモン固有名詞を含むゲーム場面を正しく認識
- [x] エクスポート ZIP に全発話分の WAV が揃うことを確認
- [x] 無音パディングで末尾ブツ切れが解消されたことを確認
- [x] pre-commit / ruff 通過