### PR TITLE
fix: ゲーム音が大きく実況音声が聞こえない問題を修正

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -271,7 +271,7 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         default_instruct=settings.tts_default_instruct,
     )
     subtitle_service = SubtitleService()
-    composer = Composer(media_root=settings.media_root)
+    composer = Composer(media_root=settings.media_root, game_audio_volume=settings.game_audio_volume)
 
     plans = (
         db.query(UtterancePlan)

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     vlm_model_name: str = "gemma3:27b"
 
     media_root: str = "/var/aituber/media"
+    game_audio_volume: float = 0.3
     log_level: str = "INFO"
 
     segment_duration: int = 5

--- a/app/core/composer.py
+++ b/app/core/composer.py
@@ -17,8 +17,13 @@ class AudioEntry:
 class Composer:
     """FFmpeg で実況音声・字幕を元動画にミックスして最終 mp4 を出力する。"""
 
-    def __init__(self, media_root: str = "/var/aituber/media") -> None:
+    def __init__(
+        self,
+        media_root: str = "/var/aituber/media",
+        game_audio_volume: float = 0.3,
+    ) -> None:
         self.media_root = Path(media_root)
+        self.game_audio_volume = game_audio_volume
 
     def compose(
         self,
@@ -55,7 +60,7 @@ class Composer:
     def _mix_audio(self, video_path: str, entries: list[AudioEntry], out_wav: str) -> None:
         """元動画音声と実況音声を amix でミックスして WAV に出力する。"""
         inputs = ["-i", video_path]
-        filter_parts = ["[0:a]volume=0.6[orig]"]
+        filter_parts = [f"[0:a]volume={self.game_audio_volume}[orig]"]
 
         for i, entry in enumerate(entries, start=1):
             inputs += ["-i", entry.audio_path]


### PR DESCRIPTION
## 概要

合成動画でゲーム音が大きすぎて実況音声（TTS）が聞こえない問題を修正。

## 原因

`_mix_audio` 内のゲーム音量が `volume=0.6` に固定されており、実況音声に対して大きすぎた。

## 修正内容

| 変更ファイル | 内容 |
|---|---|
| `app/core/composer.py` | `Composer.__init__` に `game_audio_volume: float = 0.3` を追加。固定値 0.6 → `self.game_audio_volume` に変更 |
| `app/config/config.py` | `Settings` に `game_audio_volume: float = 0.3` を追加（`.env` / DB で変更可能） |
| `app/api/videos.py` | `Composer` 初期化時に `settings.game_audio_volume` を渡すよう変更 |

## テスト手順

1. `POST /videos/{id}/compose` を実行
2. output.mp4 を再生 → 実況音声が明瞭に聞こえることを確認
3. `.env` に `GAME_AUDIO_VOLUME=0.2` を設定して再実行 → 反映されることを確認

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)