### PR TITLE
fix: WebUI 設定が process/compose に反映されない問題を修正

### DIFF
--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -25,6 +25,7 @@ _DESCRIPTIONS: dict[str, str] = {
     "vlm_model_name": "フレーム解析に使う VLM モデル名",
     "segment_duration": "動画分割のセグメント長（秒）",
     "event_grouping_window": "イベント集約ウィンドウ（秒）",
+    "game_audio_volume": "ゲーム音量比率（0.0〜1.0、実況音声に対する元動画音量）",
 }
 
 # Web UI から変更を許可するキー（database_url・media_root 等はサーバー管理）
@@ -40,6 +41,7 @@ _EDITABLE_KEYS: set[str] = {
     "vlm_model_name",
     "segment_duration",
     "event_grouping_window",
+    "game_audio_volume",
 }
 
 

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from app.clients.llm_client import LLMClient
 from app.clients.qwen_tts_client import QwenTTSClient
 from app.clients.vlm_client import VLMClient
-from app.config.config import settings
+from app.config.config import get_runtime_settings, settings
 from app.core.composer import AudioEntry, Composer
 from app.core.event_generation import EventService
 from app.core.exo_generator import ExoConfig, ExoEntry, ExoGenerator
@@ -145,24 +145,26 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     if not video:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
+    cfg = get_runtime_settings(db)
+
     seg_service = SegmentationService(
-        segment_duration=settings.segment_duration,
-        media_root=settings.media_root,
+        segment_duration=cfg.segment_duration,
+        media_root=cfg.media_root,
     )
-    frame_extractor = FrameExtractor(media_root=settings.media_root)
+    frame_extractor = FrameExtractor(media_root=cfg.media_root)
     vision_service = VisionService()
     vlm_client = VLMClient(
-        base_url=settings.llm_api_base,
-        api_key=settings.llm_api_key,
-        model=settings.vlm_model_name,
+        base_url=cfg.llm_api_base,
+        api_key=cfg.llm_api_key,
+        model=cfg.vlm_model_name,
     )
     event_service = EventService()
     planner = UtterancePlanner()
     commentary_service = CommentaryService()
     llm_client = LLMClient(
-        base_url=settings.llm_api_base,
-        api_key=settings.llm_api_key,
-        model=settings.llm_model_name,
+        base_url=cfg.llm_api_base,
+        api_key=cfg.llm_api_key,
+        model=cfg.llm_model_name,
     )
 
     update_progress(video_id, "segmentation", 0, "動画を分割中...")
@@ -263,15 +265,17 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     if not video:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
+    cfg = get_runtime_settings(db)
+
     tts_client = QwenTTSClient(
-        base_url=settings.tts_base_url,
-        default_mode=settings.tts_default_mode,
-        default_speaker=settings.tts_default_speaker,
-        default_language=settings.tts_default_language,
-        default_instruct=settings.tts_default_instruct,
+        base_url=cfg.tts_base_url,
+        default_mode=cfg.tts_default_mode,
+        default_speaker=cfg.tts_default_speaker,
+        default_language=cfg.tts_default_language,
+        default_instruct=cfg.tts_default_instruct,
     )
     subtitle_service = SubtitleService()
-    composer = Composer(media_root=settings.media_root, game_audio_volume=settings.game_audio_volume)
+    composer = Composer(media_root=cfg.media_root, game_audio_volume=cfg.game_audio_volume)
 
     plans = (
         db.query(UtterancePlan)
@@ -292,7 +296,7 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
 
         pct = int((plan_idx + 1) / plan_count * 80)
         update_progress(video_id, "tts", pct, f"音声合成中: {plan_idx + 1}/{plan_count}")
-        audio_path = str(Path(settings.media_root) / str(commentary.id) / "audio.wav")
+        audio_path = str(Path(cfg.media_root) / str(commentary.id) / "audio.wav")
         instruct = _STYLE_INSTRUCT.get(commentary.style or "", "")
         duration = tts_client.synthesize(commentary.text, audio_path, instruct=instruct)
 
@@ -308,7 +312,7 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             plan.start_time,
             duration,
             str(commentary.id),
-            settings.media_root,
+            cfg.media_root,
         )
         subtitle = Subtitle(
             commentary_id=commentary.id,
@@ -331,8 +335,8 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
 
     update_progress(video_id, "compose", 85, "字幕・動画を合成中...")
     # 全字幕を結合した SRT ファイルを生成
-    merged_srt = _merge_srt(srt_paths, video_id, settings.media_root)
-    output_path = str(Path(settings.media_root) / str(video_id) / "output.mp4")
+    merged_srt = _merge_srt(srt_paths, video_id, cfg.media_root)
+    output_path = str(Path(cfg.media_root) / str(video_id) / "output.mp4")
     composer.compose(video.storage_path, audio_entries, merged_srt, output_path)
 
     logger.info("合成完了: %s", output_path)


### PR DESCRIPTION
## 概要

WebUI の設定エディタで保存した値が `process` / `compose` 実行時に無視される問題を修正。
起動時シングルトン `settings` を使っていた箇所を `get_runtime_settings(db)` に切り替え。

## 原因

`app/api/videos.py` の `process_video` / `compose_video` が `from app.config.config import settings` の
起動時固定値を参照しており、DB に保存された設定値を見ていなかった。

## 修正内容

| エンドポイント | 切り替えた設定 |
|---|---|
| `POST /process` | `vlm_model_name` / `llm_model_name` / `llm_api_base` / `segment_duration` / `media_root` |
| `POST /compose` | `tts_base_url` / `tts_default_mode` / `tts_default_speaker` / `tts_default_language` / `tts_default_instruct` / `game_audio_volume` / `media_root` |

`upload_video` / `get_timeline` は DB runtime 設定の影響を受けないため `settings` を継続使用。

## テスト手順

1. WebUI 設定エディタで TTS モードを `voice_clone_profile` に変更して保存
2. `POST /videos/{id}/compose` を実行
3. ログを確認 → `voice_clone_profile` モードで TTS が呼ばれることを確認

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)