### PR TITLE
fix: 字幕焼き込み時に映像コーデックが未指定になる問題を修正

### DIFF
--- a/app/core/composer.py
+++ b/app/core/composer.py
@@ -118,6 +118,7 @@ class Composer:
                     "ffmpeg", "-y",
                     "-i", source,
                     "-vf", subtitle_filter,
+                    "-c:v", "libx264",
                     "-c:a", "copy",
                     output,
                 ],


### PR DESCRIPTION
## 概要

`_burn_subtitles` の `has_separate_audio=False` ブランチで `-c:v` が未指定だったため、
`-vf` フィルタ適用時に映像コーデックが不定になる問題を修正。

## 修正内容

`-c:v libx264` を追加し、字幕フィルタ適用後の再エンコードコーデックを明示指定。

## 補足

- 根本原因（音声ミックス後に映像ストリームが消える）は #25 の修正で解決済み
- `has_separate_audio=True` ブランチはすでに `-c:v libx264` が指定されており問題なし

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)