### PR TITLE
fix: make skills compatible with powershell 5.1

### DIFF
--- a/.claude/skills/new-feature/SKILL.md
+++ b/.claude/skills/new-feature/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: new-feature
-description: 新しい feature ブランチを main から切って開発を開始する
+description: 新しいブランチを main から切って開発を開始する
 ---
 
 # skill: new-feature
 
-新しい feature ブランチを main から切って開発を開始する。
+新しいブランチを main から切って開発を開始する。
 
 ## 使い方
 
 ```
-/new-feature <ブランチ名>
-例: /new-feature db-schema
+/new-feature <prefix>/<ブランチ名>
+例: /new-feature feature/db-schema
 例: /new-feature fix/tts-retry
 ```
 
@@ -19,12 +19,14 @@ description: 新しい feature ブランチを main から切って開発を開�
 
 1. main を最新に更新する
    ```bash
-   git checkout main && git pull origin main
+   git checkout main
+   git pull origin main
    ```
 
 2. ブランチを作成して移動する
    ```bash
-   git checkout -b feature/<ブランチ名>
+   git checkout -b <prefix>/<ブランチ名>
+   # 例: feature/db-schema, fix/tts-retry
    ```
 
 3. ブランチ名・目的をユーザーに確認して開発を開始する

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -18,7 +18,8 @@ description: 現在のブランチの変更をコミット → push → PR 作�
 
 1. 変更ファイルと pre-commit を確認する
    ```bash
-   git status && git diff --stat
+   git status
+   git diff --stat
    pre-commit run --all-files
    ```
 
@@ -34,8 +35,8 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    ```
 
 4. PR を作成する（関連 Issue があれば `Closes #XX` を含める）
-   ```bash
-   gh pr create --title "<type>: <概要>" --body "$(cat <<'EOF'
+   ```powershell
+   @'
    ## 概要
    <変更内容>
 
@@ -47,8 +48,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    - [ ] 異常系確認
    - [ ] テスト追加（該当時）
    - [ ] pre-commit 通過
-   EOF
-   )"
+   '@ | gh pr create --title "<type>: <概要>" --body-file -
    ```
 
 ## コミットメッセージ規則

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -31,7 +31,8 @@ description: 作業開始時に GitHub Issues を確認し、ブランチ作成�
 
 5. Issue の種別に応じたブランチを切る
    ```bash
-   git checkout main && git pull origin main
+   git checkout main
+   git pull origin main
    git checkout -b <prefix>/<issue-slug>
    # 例: feature/db-schema, fix/tts-retry
    ```

--- a/.codex/skills/new-feature/SKILL.md
+++ b/.codex/skills/new-feature/SKILL.md
@@ -10,8 +10,8 @@ description: 新しいブランチを main から切って開発を開始する
 ## 使い方
 
 ```
-/new-feature <ブランチ名>
-例: /new-feature db-schema
+/new-feature <prefix>/<ブランチ名>
+例: /new-feature feature/db-schema
 例: /new-feature fix/tts-retry
 ```
 
@@ -19,12 +19,14 @@ description: 新しいブランチを main から切って開発を開始する
 
 1. main を最新に更新する
    ```bash
-   git checkout main && git pull origin main
+   git checkout main
+   git pull origin main
    ```
 
 2. ブランチを作成して移動する
    ```bash
-   git checkout -b feature/<ブランチ名>
+   git checkout -b <prefix>/<ブランチ名>
+   # 例: feature/db-schema, fix/tts-retry
    ```
 
 3. ブランチ名・目的をユーザーに確認して開発を開始する

--- a/.codex/skills/new-feature/agents/openai.yaml
+++ b/.codex/skills/new-feature/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "New Feature Branch"
-  short_description: "main から feature ブランチを切って開発を開始する"
-  default_prompt: "main を最新に更新し、指定された名前で feature ブランチを作成して開発を開始する。ブランチ名が未指定の場合はユーザーに確認する。"
+  short_description: "main からブランチを切って開発を開始する"
+  default_prompt: "main を最新に更新し、指定された prefix/branch 形式でブランチを作成して開発を開始する。prefix が未指定なら feature/ を提案する。"

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -18,7 +18,8 @@ description: 現在のブランチの変更をコミット → push → PR 作�
 
 1. 変更ファイルと pre-commit を確認する
    ```bash
-   git status && git diff --stat
+   git status
+   git diff --stat
    pre-commit run --all-files
    ```
 
@@ -34,8 +35,8 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    ```
 
 4. PR を作成する（関連 Issue があれば `Closes #XX` を含める）
-   ```bash
-   gh pr create --title "<type>: <概要>" --body "$(cat <<'EOF'
+   ```powershell
+   @'
    ## 概要
    <変更内容>
 
@@ -47,8 +48,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    - [ ] 異常系確認
    - [ ] テスト追加（該当時）
    - [ ] pre-commit 通過
-   EOF
-   )"
+   '@ | gh pr create --title "<type>: <概要>" --body-file -
    ```
 
 ## コミットメッセージ規則

--- a/.codex/skills/start/SKILL.md
+++ b/.codex/skills/start/SKILL.md
@@ -31,7 +31,8 @@ description: 作業開始時に GitHub Issues を確認し、ブランチ作成�
 
 5. Issue に応じたブランチを切る
    ```bash
-   git checkout main && git pull origin main
+   git checkout main
+   git pull origin main
    git checkout -b <prefix>/<issue-slug>
    ```
 


### PR DESCRIPTION
## ??
- `.codex` / `.claude` ? skill ??? PowerShell 5.1 ?????????????
- `new-feature` ??????? `prefix/branch` ?????
- `.codex/skills/new-feature/agents/openai.yaml` ??????????

## ????
- `new-feature` / `start` ? `git checkout main && git pull ...` ?2????
- `ship` ? `git status && git diff --stat` ?2????
- `ship` ? PR ???? Bash heredoc ?? PowerShell here-string (`--body-file -`) ???
- `.claude/skills` ????????

## ?? Issue
Closes #52

## ??
- [x] `pre-commit run --files`?????7???????
- [x] `.codex/.claude` ??? `&&` / `$(cat <<'EOF')` ????????????
