### PR TITLE
fix: prevent overlapping commentary with scheduling guards

### DIFF
--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -26,6 +26,13 @@ _DESCRIPTIONS: dict[str, str] = {
     "segment_duration": "動画分割のセグメント長（秒）",
     "event_grouping_window": "イベント集約ウィンドウ（秒）",
     "game_audio_volume": "ゲーム音量比率（0.0〜1.0、実況音声に対する元動画音量）",
+    "planner_min_silence_seconds": "発話間に必ず空ける最小無言時間（秒）",
+    "planner_plan_duration_seconds": "発話計画の基準長（秒）",
+    "planner_speak_threshold": "この重要度未満は発話しない（0.0〜1.0）",
+    "planner_max_talk_ratio": "直近ウィンドウ内で許可する最大発話率（0.0〜1.0）",
+    "planner_talk_window_seconds": "発話率計算に使う時間窓（秒）",
+    "planner_max_queue_delay_seconds": "イベント発生から遅延許容する最大秒数（秒）",
+    "compose_overlap_min_gap_seconds": "合成時に発話同士へ追加する最小間隔（秒）",
 }
 
 # Web UI から変更を許可するキー（database_url・media_root 等はサーバー管理）
@@ -42,6 +49,13 @@ _EDITABLE_KEYS: set[str] = {
     "segment_duration",
     "event_grouping_window",
     "game_audio_volume",
+    "planner_min_silence_seconds",
+    "planner_plan_duration_seconds",
+    "planner_speak_threshold",
+    "planner_max_talk_ratio",
+    "planner_talk_window_seconds",
+    "planner_max_queue_delay_seconds",
+    "compose_overlap_min_gap_seconds",
 }
 
 

--- a/app/api/tts.py
+++ b/app/api/tts.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 
 from app.clients.qwen_tts_client import QwenTTSClient
 from app.config.config import get_runtime_settings, settings
 from app.db.session import get_db
 from app.models.schemas import TTSSynthesizeRequest
-from sqlalchemy.orm import Session
 
 router = APIRouter()
 

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -160,7 +160,14 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         model=cfg.vlm_model_name,
     )
     event_service = EventService()
-    planner = UtterancePlanner()
+    planner = UtterancePlanner(
+        min_silence_seconds=cfg.planner_min_silence_seconds,
+        plan_duration=cfg.planner_plan_duration_seconds,
+        speak_threshold=cfg.planner_speak_threshold,
+        max_talk_ratio=cfg.planner_max_talk_ratio,
+        talk_window_seconds=cfg.planner_talk_window_seconds,
+        max_queue_delay_seconds=cfg.planner_max_queue_delay_seconds,
+    )
     commentary_service = CommentaryService()
     llm_client = LLMClient(
         base_url=cfg.llm_api_base,
@@ -293,8 +300,9 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         .all()
     )
 
-    audio_entries = []
-    srt_paths = []
+    pending_entries: list[tuple[UtterancePlan, Commentary, AudioEntry]] = []
+    audio_entries: list[AudioEntry] = []
+    srt_paths: list[str] = []
     plan_count = len(plans)
     update_progress(video_id, "compose", 0, "音声合成を開始...")
 
@@ -319,10 +327,40 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             )
             db.add(audio)
 
+            pending_entries.append(
+                (
+                    plan,
+                    commentary,
+                    AudioEntry(
+                        audio_path=audio_path,
+                        start_time=plan.start_time,
+                        duration_seconds=duration,
+                    ),
+                )
+            )
+
+        normalized_entries = composer.schedule_entries(
+            [entry for _, _, entry in pending_entries],
+            min_gap_seconds=cfg.compose_overlap_min_gap_seconds,
+        )
+
+        for index, (plan, commentary, _) in enumerate(pending_entries):
+            normalized = normalized_entries[index]
+            if abs(normalized.start_time - plan.start_time) > 1e-6:
+                logger.info(
+                    "発話開始時刻を調整: plan_id=%s old=%.3f new=%.3f",
+                    plan.id,
+                    plan.start_time,
+                    normalized.start_time,
+                )
+
+            plan.start_time = normalized.start_time
+            plan.end_time = normalized.start_time + normalized.duration_seconds
+
             srt_result = subtitle_service.generate(
                 commentary.text,
-                plan.start_time,
-                duration,
+                normalized.start_time,
+                normalized.duration_seconds,
                 str(commentary.id),
                 cfg.media_root,
             )
@@ -333,12 +371,11 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
                 end_time=srt_result.end_time,
             )
             db.add(subtitle)
-
             audio_entries.append(
                 AudioEntry(
-                    audio_path=audio_path,
-                    start_time=plan.start_time,
-                    duration_seconds=duration,
+                    audio_path=normalized.audio_path,
+                    start_time=normalized.start_time,
+                    duration_seconds=normalized.duration_seconds,
                 )
             )
             srt_paths.append(srt_result.file_path)

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -29,6 +29,13 @@ class Settings(BaseSettings):
 
     segment_duration: int = 5
     event_grouping_window: int = 3
+    planner_min_silence_seconds: float = 2.0
+    planner_plan_duration_seconds: float = 3.0
+    planner_speak_threshold: float = 0.3
+    planner_max_talk_ratio: float = 0.5
+    planner_talk_window_seconds: float = 60.0
+    planner_max_queue_delay_seconds: float = 3.0
+    compose_overlap_min_gap_seconds: float = 0.0
 
     model_config = {"env_file": ".env"}
 

--- a/app/core/composer.py
+++ b/app/core/composer.py
@@ -36,8 +36,9 @@ class Composer:
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
         if audio_entries:
+            safe_audio_entries = self.schedule_entries(audio_entries)
             mixed_audio = str(Path(output_path).parent / "mixed_audio.wav")
-            self._mix_audio(video_path, audio_entries, mixed_audio)
+            self._mix_audio(video_path, safe_audio_entries, mixed_audio)
             source = mixed_audio
         else:
             source = video_path
@@ -56,6 +57,34 @@ class Composer:
             )
 
         return output_path
+
+    def schedule_entries(
+        self,
+        entries: list[AudioEntry],
+        min_gap_seconds: float = 0.0,
+    ) -> list[AudioEntry]:
+        """重複しないように音声エントリ開始時刻を正規化する。"""
+        if not entries:
+            return []
+
+        sorted_entries = sorted(entries, key=lambda e: e.start_time)
+        gap = max(0.0, min_gap_seconds)
+        next_available = 0.0
+        normalized: list[AudioEntry] = []
+
+        for entry in sorted_entries:
+            start_time = max(entry.start_time, next_available)
+            duration = max(0.0, entry.duration_seconds)
+            normalized.append(
+                AudioEntry(
+                    audio_path=entry.audio_path,
+                    start_time=start_time,
+                    duration_seconds=duration,
+                )
+            )
+            next_available = start_time + duration + gap
+
+        return normalized
 
     def _mix_audio(self, video_path: str, entries: list[AudioEntry], out_wav: str) -> None:
         """元動画音声と実況音声を amix でミックスして WAV に出力する。"""

--- a/app/core/planning.py
+++ b/app/core/planning.py
@@ -20,7 +20,7 @@ class UtterancePlanResult:
 class UtterancePlanner:
     """イベントリストから発話計画を生成する。
 
-    連続発話を抑制し、importance に応じてスタイルを決定する。
+    連続発話を抑制し、無言時間を許可しながら importance に応じてスタイルを決定する。
     """
 
     # importance → style マッピング（閾値の降順）
@@ -30,30 +30,52 @@ class UtterancePlanner:
         (0.0, "calm"),
     ]
 
-    def __init__(self, min_silence_seconds: float = 2.0, plan_duration: float = 3.0) -> None:
-        self.min_silence_seconds = min_silence_seconds
-        self.plan_duration = plan_duration
+    def __init__(
+        self,
+        min_silence_seconds: float = 2.0,
+        plan_duration: float = 3.0,
+        speak_threshold: float = 0.3,
+        max_talk_ratio: float = 0.5,
+        talk_window_seconds: float = 60.0,
+        max_queue_delay_seconds: float = 3.0,
+    ) -> None:
+        self.min_silence_seconds = max(0.0, min_silence_seconds)
+        self.plan_duration = max(0.1, plan_duration)
+        self.speak_threshold = max(0.0, min(1.0, speak_threshold))
+        self.max_talk_ratio = max(0.0, min(1.0, max_talk_ratio))
+        self.talk_window_seconds = max(1.0, talk_window_seconds)
+        self.max_queue_delay_seconds = max(0.0, max_queue_delay_seconds)
 
     def plan(self, video_id: str, events: list[EventResult]) -> list[UtterancePlanResult]:
         """speak_recommended なイベントから発話計画を生成する。"""
-        candidates = [e for e in events if e.speak_recommended]
+        candidates = [
+            event
+            for event in events
+            if event.speak_recommended and event.importance >= self.speak_threshold
+        ]
+        candidates = self._deduplicate_same_timestamp(candidates)
         candidates.sort(key=lambda e: e.timestamp)
 
         plans: list[UtterancePlanResult] = []
         last_end_time = -self.min_silence_seconds
 
         for event in candidates:
-            # 直前発話終了から min_silence_seconds 以上空いていない場合はスキップ
-            if event.timestamp < last_end_time + self.min_silence_seconds:
+            # 重複を回避するため、開始時刻を「前発話終了 + 無言時間」以降に寄せる。
+            start_time = max(event.timestamp, last_end_time + self.min_silence_seconds)
+            queue_delay = start_time - event.timestamp
+            if queue_delay > self.max_queue_delay_seconds:
                 continue
 
-            end_time = event.timestamp + self.plan_duration
+            end_time = start_time + self.plan_duration
+            if self._would_exceed_talk_ratio(plans, start_time, end_time):
+                continue
+
             plans.append(
                 UtterancePlanResult(
                     plan_id=str(uuid.uuid4()),
                     video_id=video_id,
                     event_ids=[event.event_id],
-                    start_time=event.timestamp,
+                    start_time=start_time,
                     end_time=end_time,
                     priority=self._calc_priority(event.importance),
                     style=self._resolve_style(event.importance),
@@ -62,6 +84,34 @@ class UtterancePlanner:
             last_end_time = end_time
 
         return plans
+
+    def _deduplicate_same_timestamp(self, events: list[EventResult]) -> list[EventResult]:
+        """同一 timestamp の候補が複数ある場合は importance が最大の 1 件に絞る。"""
+        best_by_timestamp: dict[float, EventResult] = {}
+        for event in events:
+            current = best_by_timestamp.get(event.timestamp)
+            if current is None or event.importance > current.importance:
+                best_by_timestamp[event.timestamp] = event
+        return list(best_by_timestamp.values())
+
+    def _would_exceed_talk_ratio(
+        self,
+        accepted_plans: list[UtterancePlanResult],
+        new_start_time: float,
+        new_end_time: float,
+    ) -> bool:
+        """直近ウィンドウの発話率上限を超える場合は True を返す。"""
+        window_start = max(0.0, new_start_time - self.talk_window_seconds)
+        spoken_seconds = 0.0
+
+        for plan in accepted_plans:
+            overlap_start = max(window_start, plan.start_time)
+            overlap_end = min(new_start_time, plan.end_time)
+            if overlap_end > overlap_start:
+                spoken_seconds += overlap_end - overlap_start
+
+        projected = spoken_seconds + max(0.0, new_end_time - new_start_time)
+        return (projected / self.talk_window_seconds) > self.max_talk_ratio
 
     def _resolve_style(self, importance: float) -> str:
         for threshold, style in self._STYLE_MAP:

--- a/tests/test_core/test_composer.py
+++ b/tests/test_core/test_composer.py
@@ -1,0 +1,29 @@
+from app.core.composer import AudioEntry, Composer
+
+
+class TestComposer:
+    def test_schedule_entries_shifts_overlap(self) -> None:
+        composer = Composer()
+        entries = [
+            AudioEntry(audio_path="a.wav", start_time=0.0, duration_seconds=2.0),
+            AudioEntry(audio_path="b.wav", start_time=1.0, duration_seconds=1.5),
+        ]
+
+        normalized = composer.schedule_entries(entries)
+
+        assert len(normalized) == 2
+        assert normalized[0].start_time == 0.0
+        assert normalized[1].start_time == 2.0
+
+    def test_schedule_entries_respects_min_gap(self) -> None:
+        composer = Composer()
+        entries = [
+            AudioEntry(audio_path="a.wav", start_time=0.0, duration_seconds=1.0),
+            AudioEntry(audio_path="b.wav", start_time=0.5, duration_seconds=1.0),
+        ]
+
+        normalized = composer.schedule_entries(entries, min_gap_seconds=0.5)
+
+        assert len(normalized) == 2
+        assert normalized[0].start_time == 0.0
+        assert normalized[1].start_time == 1.5

--- a/tests/test_core/test_planning.py
+++ b/tests/test_core/test_planning.py
@@ -44,3 +44,40 @@ class TestUtterancePlanner:
         )
         plans = self.planner.plan("vid-1", [event])
         assert len(plans) == 0
+
+    def test_low_importance_is_silenced_by_threshold(self) -> None:
+        planner = UtterancePlanner(
+            min_silence_seconds=0.0,
+            plan_duration=2.0,
+            speak_threshold=0.6,
+        )
+        events = [_make_event(0.0, importance=0.5)]
+        plans = planner.plan("vid-1", events)
+        assert len(plans) == 0
+
+    def test_start_time_shifted_when_overlap_would_happen(self) -> None:
+        planner = UtterancePlanner(
+            min_silence_seconds=1.0,
+            plan_duration=3.0,
+            max_queue_delay_seconds=5.0,
+        )
+        events = [_make_event(0.0, importance=0.9), _make_event(1.0, importance=0.9)]
+        plans = planner.plan("vid-1", events)
+        assert len(plans) == 2
+        assert plans[0].start_time == 0.0
+        assert plans[1].start_time == 4.0
+
+    def test_talk_ratio_limit_creates_silence(self) -> None:
+        planner = UtterancePlanner(
+            min_silence_seconds=0.0,
+            plan_duration=3.0,
+            max_talk_ratio=0.4,
+            talk_window_seconds=10.0,
+            max_queue_delay_seconds=0.0,
+        )
+        events = [
+            _make_event(0.0, importance=0.9),
+            _make_event(5.0, importance=0.9),
+        ]
+        plans = planner.plan("vid-1", events)
+        assert len(plans) == 1


### PR DESCRIPTION
## 概要
- 発話計画で無言時間・発話閾値・発話率上限・キュー遅延上限を導入し、重複しない発話計画を生成
- compose 時に音声エントリを正規化する安全網を追加し、実測 duration ベースで字幕/plan 時刻を同期
- runtime settings に planner/composer の制御パラメータを追加
- planner/composer の単体テストを追加

## 関連 Issue
Closes #41

## 確認事項
- [x] ruff check app tests
- [x] pytest tests -q
- [ ] 正常系の手動確認（E2E）
- [ ] 異常系の手動確認（E2E）