### PR TITLE
feat: add video tag metadata foundation

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -25,6 +25,7 @@ from app.core.progress_store import update_progress
 from app.core.prompt import CommentaryService
 from app.core.segmentation import FrameExtractor, SegmentationService
 from app.core.subtitle import SubtitleService
+from app.core.tags import normalize_video_metadata
 from app.core.vision import VisionService
 from app.db.session import get_db
 from app.models.models import (
@@ -58,7 +59,7 @@ def upload_video(
     title: str = Query(default=""),
     file: UploadFile = File(...),
     db: Session = Depends(get_db),
-) -> Video:
+) -> VideoRead:
     """動画ファイルをアップロードして DB に登録する。"""
     video_id = uuid.uuid4()
     media_dir = Path(settings.media_root) / str(video_id)
@@ -89,17 +90,19 @@ def upload_video(
         duration_seconds=duration,
         fps=fps,
         storage_path=str(dest_path),
+        video_metadata=normalize_video_metadata(None),
     )
     db.add(video)
     db.commit()
     db.refresh(video)
     logger.info("動画登録: video_id=%s", video_id)
-    return video
+    return _to_video_read(video)
 
 
 @router.get("/", response_model=list[VideoRead])
-def list_videos(db: Session = Depends(get_db)) -> list[Video]:
-    return db.query(Video).order_by(Video.created_at.desc()).all()
+def list_videos(db: Session = Depends(get_db)) -> list[VideoRead]:
+    videos = db.query(Video).order_by(Video.created_at.desc()).all()
+    return [_to_video_read(video) for video in videos]
 
 
 @router.delete("/{video_id}")
@@ -130,15 +133,15 @@ def delete_video(video_id: str, db: Session = Depends(get_db)) -> dict:
 
 
 @router.get("/{video_id}", response_model=VideoRead)
-def get_video(video_id: str, db: Session = Depends(get_db)) -> Video:
+def get_video(video_id: str, db: Session = Depends(get_db)) -> VideoRead:
     video = db.query(Video).filter(Video.id == video_id).first()
     if not video:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
-    return video
+    return _to_video_read(video)
 
 
 @router.patch("/{video_id}", response_model=VideoRead)
-def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_db)) -> Video:
+def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_db)) -> VideoRead:
     """動画のタイトル・タグを更新する。"""
     video = db.query(Video).filter(Video.id == video_id).first()
     if not video:
@@ -151,9 +154,9 @@ def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_
         video.title = new_title
 
     if payload.tags is not None:
-        metadata = dict(video.video_metadata or {})
-        metadata["tags"] = _normalize_tags(payload.tags)
-        video.video_metadata = metadata
+        metadata = normalize_video_metadata(video.video_metadata)
+        metadata["tags_manual"] = _normalize_tags(payload.tags)
+        video.video_metadata = normalize_video_metadata(metadata)
 
     try:
         db.add(video)
@@ -164,7 +167,7 @@ def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_
         logger.error("動画更新失敗: %s", e)
         raise HTTPException(status_code=500, detail="動画更新に失敗しました") from e
 
-    return video
+    return _to_video_read(video)
 
 
 @router.get("/{video_id}/timeline", response_model=VideoTimeline)
@@ -215,6 +218,7 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     video = db.query(Video).filter(Video.id == video_id).first()
     if not video:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video.video_metadata = normalize_video_metadata(video.video_metadata)
 
     cfg = get_runtime_settings(db)
 
@@ -627,4 +631,18 @@ def _generate_thumbnail(video_path: str, thumbnail_path: str) -> None:
         ],
         check=True,
         capture_output=True,
+    )
+
+
+def _to_video_read(video: Video) -> VideoRead:
+    """動画レスポンス用にタグメタデータを正規化する。"""
+    metadata = normalize_video_metadata(video.video_metadata)
+    return VideoRead(
+        id=video.id,
+        title=video.title,
+        duration_seconds=video.duration_seconds,
+        fps=video.fps,
+        storage_path=video.storage_path,
+        video_metadata=metadata,
+        created_at=video.created_at,
     )

--- a/app/core/tags.py
+++ b/app/core/tags.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any
+
+# システム由来タグ（設定・動画メタ情報）
+SYSTEM_TAG_PREFIXES: tuple[str, ...] = (
+    "cfg:tts_mode:",
+    "cfg:llm_model:",
+    "cfg:vlm_model:",
+    "video:length:",
+    "video:fps:",
+)
+
+# 内容由来タグ（解析結果）
+CONTENT_TAG_PREFIXES: tuple[str, ...] = (
+    "category:",
+    "genre:",
+    "game:",
+    "topic:",
+    "candidate:",
+)
+
+TAG_TAXONOMY: dict[str, list[str]] = {
+    "system": list(SYSTEM_TAG_PREFIXES),
+    "content": list(CONTENT_TAG_PREFIXES),
+}
+
+_DEFAULT_STATUS = {
+    "rule": "pending",
+    "llm": "pending",
+    "llm_error": None,
+}
+_ALLOWED_STATUS = {"pending", "ready", "error", "skipped"}
+
+
+def normalize_video_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    """動画メタデータのタグ関連キーを正規化して返す。"""
+    raw = metadata if isinstance(metadata, dict) else {}
+
+    tags_manual = normalize_tags(raw.get("tags_manual"))
+    tags_auto_rule = normalize_tags(raw.get("tags_auto_rule"))
+    tags_auto_llm = normalize_tags(raw.get("tags_auto_llm"))
+    tags_suggested_llm = normalize_tags(raw.get("tags_suggested_llm"))
+    tag_status = normalize_tag_status(raw.get("tag_status"))
+    tags_effective = merge_effective_tags(tags_manual, tags_auto_rule, tags_auto_llm)
+
+    normalized = dict(raw)
+    normalized.update(
+        {
+            "tags_manual": tags_manual,
+            "tags_auto_rule": tags_auto_rule,
+            "tags_auto_llm": tags_auto_llm,
+            "tags_suggested_llm": tags_suggested_llm,
+            "tags_effective": tags_effective,
+            "tag_status": tag_status,
+        }
+    )
+    return normalized
+
+
+def normalize_tags(value: Any) -> list[str]:
+    """タグ配列を重複除去・空要素除去して正規化する。"""
+    if not isinstance(value, list):
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_tag in value:
+        if not isinstance(raw_tag, str):
+            continue
+        tag = raw_tag.strip()
+        if not tag or tag in seen or not is_taxonomy_tag(tag):
+            continue
+        normalized.append(tag)
+        seen.add(tag)
+    return normalized
+
+
+def normalize_tag_status(value: Any) -> dict[str, str | None]:
+    """タグ処理ステータスを既定値付きで正規化する。"""
+    status = dict(_DEFAULT_STATUS)
+    if not isinstance(value, dict):
+        return status
+
+    for key in ("rule", "llm"):
+        raw = value.get(key)
+        if isinstance(raw, str) and raw in _ALLOWED_STATUS:
+            status[key] = raw
+
+    llm_error = value.get("llm_error")
+    if isinstance(llm_error, str):
+        stripped = llm_error.strip()
+        status["llm_error"] = stripped if stripped else None
+    return status
+
+
+def merge_effective_tags(
+    tags_manual: list[str],
+    tags_auto_rule: list[str],
+    tags_auto_llm: list[str],
+) -> list[str]:
+    """manual > rule > llm 優先で tags_effective を合成する。"""
+    family_map: dict[str, str] = {}
+
+    # 先に低優先を入れ、高優先で上書きする。
+    for source_tags in (tags_auto_llm, tags_auto_rule, tags_manual):
+        for tag in source_tags:
+            family_map[_tag_family(tag)] = tag
+
+    return list(family_map.values())
+
+
+def is_taxonomy_tag(tag: str) -> bool:
+    """定義済み taxonomy（system/content）に含まれるタグか判定する。"""
+    return tag.startswith(SYSTEM_TAG_PREFIXES) or tag.startswith(CONTENT_TAG_PREFIXES)
+
+
+def _tag_family(tag: str) -> str:
+    """優先順位解決に使うタグ族キーを返す。"""
+    parts = tag.split(":")
+    if len(parts) <= 1:
+        return tag
+    if len(parts) == 2:
+        return parts[0]
+    return ":".join(parts[:-1])

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -19,7 +19,7 @@ class VideoRead(BaseModel):
     duration_seconds: float | None
     fps: float | None
     storage_path: str
-    video_metadata: dict[str, Any] | None = None
+    video_metadata: dict[str, Any]
     created_at: datetime | None
 
 

--- a/tests/test_core/test_tags.py
+++ b/tests/test_core/test_tags.py
@@ -1,0 +1,54 @@
+from app.core.tags import merge_effective_tags, normalize_tags, normalize_video_metadata
+
+
+def test_merge_effective_tags_applies_manual_rule_llm_priority() -> None:
+    manual = ["genre:rpg", "cfg:tts_mode:custom_voice"]
+    rule = ["genre:action", "video:fps:60"]
+    llm = ["genre:strategy", "game:elden_ring"]
+
+    effective = merge_effective_tags(manual, rule, llm)
+
+    assert "genre:rpg" in effective
+    assert "genre:action" not in effective
+    assert "genre:strategy" not in effective
+    assert "cfg:tts_mode:custom_voice" in effective
+    assert "video:fps:60" in effective
+    assert "game:elden_ring" in effective
+
+
+def test_normalize_video_metadata_sets_required_keys_and_effective_tags() -> None:
+    metadata = {
+        "tags_manual": ["genre:racing"],
+        "tags_auto_rule": ["cfg:tts_mode:voice_design"],
+        "tags_auto_llm": ["game:mario_kart"],
+        "extra": "keep",
+    }
+
+    normalized = normalize_video_metadata(metadata)
+
+    assert normalized["extra"] == "keep"
+    assert normalized["tags_manual"] == ["genre:racing"]
+    assert normalized["tags_auto_rule"] == ["cfg:tts_mode:voice_design"]
+    assert normalized["tags_auto_llm"] == ["game:mario_kart"]
+    assert normalized["tags_suggested_llm"] == []
+    assert normalized["tag_status"] == {"rule": "pending", "llm": "pending", "llm_error": None}
+    assert set(normalized["tags_effective"]) == {
+        "cfg:tts_mode:voice_design",
+        "game:mario_kart",
+        "genre:racing",
+    }
+
+
+def test_normalize_tags_filters_unknown_and_duplicate_tags() -> None:
+    raw = [
+        " genre:rpg ",
+        "genre:rpg",
+        "unknown_tag",
+        "game:elden_ring",
+        "",
+        123,
+    ]
+
+    normalized = normalize_tags(raw)
+
+    assert normalized == ["genre:rpg", "game:elden_ring"]


### PR DESCRIPTION
## 概要
- 自動タグ基盤として taxonomy（system/content）とタグ正規化ロジックを追加
- `video_metadata` を `tags_manual / tags_auto_rule / tags_auto_llm / tags_suggested_llm / tags_effective / tag_status` へ正規化
- `tags_effective` を `manual > rule > llm` 優先で計算
- `/videos` 系レスポンスを正規化済み `video_metadata` で返却

## 関連 Issue
Closes #60

## 確認
- [x] ruff check app tests
- [x] pytest tests -q