### PR TITLE
feat: add rule-based video tag generation

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -23,6 +23,7 @@ from app.core.exo_generator import ExoConfig, ExoEntry, ExoGenerator
 from app.core.planning import UtterancePlanner
 from app.core.progress_store import update_progress
 from app.core.prompt import CommentaryService
+from app.core.rule_tagger import RuleTagger
 from app.core.segmentation import FrameExtractor, SegmentationService
 from app.core.subtitle import SubtitleService
 from app.core.tags import normalize_video_metadata
@@ -218,9 +219,23 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     video = db.query(Video).filter(Video.id == video_id).first()
     if not video:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
-    video.video_metadata = normalize_video_metadata(video.video_metadata)
 
     cfg = get_runtime_settings(db)
+    rule_tagger = RuleTagger()
+    metadata = normalize_video_metadata(video.video_metadata)
+    metadata["tags_auto_rule"] = rule_tagger.generate(
+        tts_mode=cfg.tts_default_mode,
+        llm_model=cfg.llm_model_name,
+        vlm_model=cfg.vlm_model_name,
+        duration_seconds=video.duration_seconds,
+        fps=video.fps,
+    )
+    tag_status = dict(metadata.get("tag_status", {}))
+    tag_status["rule"] = "ready"
+    metadata["tag_status"] = tag_status
+    video.video_metadata = normalize_video_metadata(metadata)
+    db.add(video)
+    db.commit()
 
     seg_service = SegmentationService(
         segment_duration=cfg.segment_duration,

--- a/app/core/rule_tagger.py
+++ b/app/core/rule_tagger.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+
+
+class RuleTagger:
+    """設定値と動画メタから機械的タグを生成する。"""
+
+    _SANITIZE_PATTERN = re.compile(r"[^a-z0-9._-]+")
+
+    def generate(
+        self,
+        *,
+        tts_mode: str,
+        llm_model: str,
+        vlm_model: str,
+        duration_seconds: float | None,
+        fps: float | None,
+    ) -> list[str]:
+        tags: list[str] = []
+
+        tags.append(f"cfg:tts_mode:{self._sanitize(tts_mode)}")
+        tags.append(f"cfg:llm_model:{self._sanitize(llm_model)}")
+        tags.append(f"cfg:vlm_model:{self._sanitize(vlm_model)}")
+        tags.append(f"video:length:{self._length_bucket(duration_seconds)}")
+        tags.append(f"video:fps:{self._fps_bucket(fps)}")
+        return tags
+
+    def _sanitize(self, value: str) -> str:
+        normalized = self._SANITIZE_PATTERN.sub("_", value.strip().lower())
+        return normalized.strip("_") or "unknown"
+
+    def _length_bucket(self, duration_seconds: float | None) -> str:
+        if duration_seconds is None or duration_seconds <= 0:
+            return "unknown"
+        if duration_seconds < 60:
+            return "short"
+        if duration_seconds < 300:
+            return "medium"
+        return "long"
+
+    def _fps_bucket(self, fps: float | None) -> str:
+        if fps is None or fps <= 0:
+            return "unknown"
+        return str(int(round(fps)))

--- a/tests/test_core/test_rule_tagger.py
+++ b/tests/test_core/test_rule_tagger.py
@@ -1,0 +1,63 @@
+from app.core.rule_tagger import RuleTagger
+
+
+def test_generate_returns_expected_rule_tags() -> None:
+    tagger = RuleTagger()
+
+    tags = tagger.generate(
+        tts_mode="custom_voice",
+        llm_model="gpt-4-turbo",
+        vlm_model="gemma3:27b",
+        duration_seconds=180.0,
+        fps=29.97,
+    )
+
+    assert tags == [
+        "cfg:tts_mode:custom_voice",
+        "cfg:llm_model:gpt-4-turbo",
+        "cfg:vlm_model:gemma3_27b",
+        "video:length:medium",
+        "video:fps:30",
+    ]
+
+
+def test_generate_uses_unknown_bucket_for_invalid_values() -> None:
+    tagger = RuleTagger()
+
+    tags = tagger.generate(
+        tts_mode="",
+        llm_model=" ",
+        vlm_model="@@@",
+        duration_seconds=None,
+        fps=0.0,
+    )
+
+    assert tags == [
+        "cfg:tts_mode:unknown",
+        "cfg:llm_model:unknown",
+        "cfg:vlm_model:unknown",
+        "video:length:unknown",
+        "video:fps:unknown",
+    ]
+
+
+def test_generate_length_bucket_for_short_and_long() -> None:
+    tagger = RuleTagger()
+
+    short_tags = tagger.generate(
+        tts_mode="custom_voice",
+        llm_model="gpt-4o-mini",
+        vlm_model="gemma3:27b",
+        duration_seconds=10.0,
+        fps=60.0,
+    )
+    long_tags = tagger.generate(
+        tts_mode="custom_voice",
+        llm_model="gpt-4o-mini",
+        vlm_model="gemma3:27b",
+        duration_seconds=600.0,
+        fps=60.0,
+    )
+
+    assert "video:length:short" in short_tags
+    assert "video:length:long" in long_tags


### PR DESCRIPTION
## 概要
- `RuleTagger` を追加し、設定値と動画メタ情報から機械タグを生成
- `/videos/{video_id}/process` の先頭で `RuleTagger` を実行し、`tags_auto_rule` と `tag_status.rule=ready` を更新
- `RuleTagger` の単体テストを追加

## 関連 Issue
Closes #61

## 確認事項
- [x] 正常系確認
- [x] 異常系確認
- [x] テスト追加（該当時）
- [ ] pre-commit 通過
