### PR TITLE
chore: add gitattributes for lf normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## 概要
- `.gitattributes` を追加し、改行コードを LF に統一
- `* text=auto eol=lf` を設定

## 目的
- CRLF/LF のノイズ差分を抑止し、pre-commit 運用を安定化
