### PR TITLE
chore: document branch cleanup after merge in start and ship skills

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -79,8 +79,14 @@ description: 現在のブランチの変更をコミット → push → PR 作�
 5. マージと後処理
    ```bash
    gh pr merge <PR番号> --merge --delete-branch
+   git checkout main
+   git pull origin main
+   git branch -d <作業ブランチ>
+   git push origin --delete <作業ブランチ> || true
    git worktree remove --force /tmp/<repo>-ship
    ```
+
+- 方針: PR マージ後は、不要になったブランチを削除して `main` に戻した状態を作業の終了条件にする
 
 ## コミットメッセージ規則
 

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -51,6 +51,18 @@ description: 作業開始時に GitHub Issues を確認し、ブランチ作成�
    gh issue comment <番号> --body "作業開始します。ブランチ: \`<ブランチ名>\`"
    ```
 
+## 運用ルール（完了時）
+
+- 対象 Issue の PR をマージしたら、不要になった作業ブランチは削除する
+- マージ作業後は `main` に戻る
+- 例:
+  ```bash
+  git checkout main
+  git pull origin main
+  git branch -d <作業ブランチ>
+  git push origin --delete <作業ブランチ>
+  ```
+
 ## 実行エラー時の原則
 
 - 権限不足・コマンド未導入・認証未完了で止まったら、まずユーザーに状況を共有して実行依頼する

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -79,8 +79,14 @@ description: 現在のブランチの変更をコミット → push → PR 作�
 5. マージと後処理
    ```bash
    gh pr merge <PR番号> --merge --delete-branch
+   git checkout main
+   git pull origin main
+   git branch -d <作業ブランチ>
+   git push origin --delete <作業ブランチ> || true
    git worktree remove --force /tmp/<repo>-ship
    ```
+
+- 方針: PR マージ後は、不要になったブランチを削除して `main` に戻した状態を作業の終了条件にする
 
 ## コミットメッセージ規則
 

--- a/.codex/skills/start/SKILL.md
+++ b/.codex/skills/start/SKILL.md
@@ -50,6 +50,18 @@ description: 作業開始時に GitHub Issues を確認し、ブランチ作成�
    gh issue comment <番号> --body "作業開始します。ブランチ: \`<ブランチ名>\`"
    ```
 
+## 運用ルール（完了時）
+
+- 対象 Issue の PR をマージしたら、不要になった作業ブランチは削除する
+- マージ作業後は `main` に戻る
+- 例:
+  ```bash
+  git checkout main
+  git pull origin main
+  git branch -d <作業ブランチ>
+  git push origin --delete <作業ブランチ>
+  ```
+
 ## 実行エラー時の原則
 
 - 権限不足・コマンド未導入・認証未完了で止まったら、まずユーザーに状況を共有して実行依頼する


### PR DESCRIPTION
## 概要
- `start` スキルに、PR マージ後の不要ブランチ削除と `main` 復帰ルールを追記
- `ship` スキルに、PR マージ後のブランチ削除と `main` 復帰を終了条件として追記
- `gh pr merge --delete-branch` 後でも安全なように、リモートブランチ削除コマンドを冪等化

## 確認事項
- [x] `.codex` / `.claude` の同期
- [x] スキル文面のみの更新
