### PR TITLE
chore: standardize start skill comments via body-file

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -48,7 +48,16 @@ description: 作業開始時に GitHub Issues を確認し、ブランチ作成�
 
 6. Issue に作業開始コメントを残す
    ```bash
-   gh issue comment <番号> --body "作業開始します。ブランチ: \`<ブランチ名>\`"
+   tmp_file=$(mktemp)
+   cat <<EOF > "$tmp_file"
+   作業開始します。ブランチ: <ブランチ名>
+
+   今回の実装方針:
+   - <方針1>
+   - <方針2>
+   EOF
+   gh issue comment <番号> --body-file "$tmp_file"
+   rm -f "$tmp_file"
    ```
 
 ## 運用ルール（完了時）

--- a/.codex/skills/start/SKILL.md
+++ b/.codex/skills/start/SKILL.md
@@ -47,7 +47,16 @@ description: 作業開始時に GitHub Issues を確認し、ブランチ作成�
 
 6. Issue に作業開始コメントを残す
    ```bash
-   gh issue comment <番号> --body "作業開始します。ブランチ: \`<ブランチ名>\`"
+   tmp_file=$(mktemp)
+   cat <<EOF > "$tmp_file"
+   作業開始します。ブランチ: <ブランチ名>
+
+   今回の実装方針:
+   - <方針1>
+   - <方針2>
+   EOF
+   gh issue comment <番号> --body-file "$tmp_file"
+   rm -f "$tmp_file"
    ```
 
 ## 運用ルール（完了時）


### PR DESCRIPTION
## 概要
- `start` スキルの Issue コメント投稿を `--body-file` 標準に変更
- `mktemp` で生成した一時ファイルを投稿後に削除する手順を追加
- `.codex` / `.claude` の両方を同期更新

## 関連
- Related #62

## 確認事項
- [x] スキル文面更新のみ
- [x] pre-commit 通過
