### PR TITLE
chore: avoid duplicate remote branch delete in ship skill

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -81,8 +81,10 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    gh pr merge <PR番号> --merge --delete-branch
    git checkout main
    git pull origin main
-   git branch -d <作業ブランチ>
-   git push origin --delete <作業ブランチ> || true
+   git branch -d <作業ブランチ> || true
+   if git ls-remote --exit-code --heads origin <作業ブランチ> >/dev/null 2>&1; then
+     git push origin --delete <作業ブランチ>
+   fi
    git worktree remove --force /tmp/<repo>-ship
    ```
 

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -81,8 +81,10 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    gh pr merge <PR番号> --merge --delete-branch
    git checkout main
    git pull origin main
-   git branch -d <作業ブランチ>
-   git push origin --delete <作業ブランチ> || true
+   git branch -d <作業ブランチ> || true
+   if git ls-remote --exit-code --heads origin <作業ブランチ> >/dev/null 2>&1; then
+     git push origin --delete <作業ブランチ>
+   fi
    git worktree remove --force /tmp/<repo>-ship
    ```
 


### PR DESCRIPTION
## 概要
- `ship` スキルの後処理で、リモートブランチ削除を条件付きに変更
- `gh pr merge --delete-branch` 後に不要な二重削除エラーを出さないよう改善
- `.codex` / `.claude` の両方を同期更新

## 確認事項
- [x] スキル文面更新のみ
