### PR TITLE
feat: add tag management api and ui refresh flow

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -7,6 +7,7 @@ import subprocess
 import uuid
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import cv2
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
@@ -26,7 +27,11 @@ from app.core.prompt import CommentaryService
 from app.core.rule_tagger import RuleTagger
 from app.core.segmentation import FrameExtractor, SegmentationService
 from app.core.subtitle import SubtitleService
-from app.core.tags import normalize_video_metadata
+from app.core.tags import (
+    build_tag_source_map,
+    mark_llm_tag_status_skipped,
+    normalize_video_metadata,
+)
 from app.core.vision import VisionService
 from app.db.session import get_db
 from app.models.models import (
@@ -39,7 +44,7 @@ from app.models.models import (
     UtterancePlan,
     Video,
 )
-from app.models.schemas import TimelineItem, VideoRead, VideoTimeline, VideoUpdate
+from app.models.schemas import TimelineItem, VideoRead, VideoTagRead, VideoTimeline, VideoUpdate
 from app.utils.logging import logger
 
 router = APIRouter()
@@ -141,6 +146,15 @@ def get_video(video_id: str, db: Session = Depends(get_db)) -> VideoRead:
     return _to_video_read(video)
 
 
+@router.get("/{video_id}/tags", response_model=VideoTagRead)
+def get_video_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTagRead:
+    """動画タグ（manual/rule/llm/effective）とソース情報を返す。"""
+    video = db.query(Video).filter(Video.id == video_id).first()
+    if not video:
+        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    return _to_video_tag_read(video.video_metadata)
+
+
 @router.patch("/{video_id}", response_model=VideoRead)
 def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_db)) -> VideoRead:
     """動画のタイトル・タグを更新する。"""
@@ -154,9 +168,10 @@ def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_
             raise HTTPException(status_code=400, detail="タイトルが空です")
         video.title = new_title
 
-    if payload.tags is not None:
+    manual_tags = payload.tags_manual if payload.tags_manual is not None else payload.tags
+    if manual_tags is not None:
         metadata = normalize_video_metadata(video.video_metadata)
-        metadata["tags_manual"] = _normalize_tags(payload.tags)
+        metadata["tags_manual"] = _normalize_tags(manual_tags)
         video.video_metadata = normalize_video_metadata(metadata)
 
     try:
@@ -169,6 +184,75 @@ def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_
         raise HTTPException(status_code=500, detail="動画更新に失敗しました") from e
 
     return _to_video_read(video)
+
+
+@router.post("/{video_id}/tags/rule:refresh", response_model=VideoTagRead)
+def refresh_video_rule_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTagRead:
+    """RuleTagger で tags_auto_rule を再生成する。"""
+    video = db.query(Video).filter(Video.id == video_id).first()
+    if not video:
+        raise HTTPException(status_code=404, detail="動画が見つかりません")
+
+    cfg = get_runtime_settings(db)
+    metadata = _refresh_rule_tags(video, cfg)
+    video.video_metadata = metadata
+
+    try:
+        db.add(video)
+        db.commit()
+        db.refresh(video)
+    except Exception as e:
+        db.rollback()
+        logger.error("rule タグ再生成失敗: %s", e)
+        raise HTTPException(status_code=500, detail="rule タグ再生成に失敗しました") from e
+
+    return _to_video_tag_read(video.video_metadata)
+
+
+@router.post("/{video_id}/tags/llm:refresh", response_model=VideoTagRead)
+def refresh_video_llm_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTagRead:
+    """LLM タグ再生成を実行する（現状は未実装のためスキップ）。"""
+    video = db.query(Video).filter(Video.id == video_id).first()
+    if not video:
+        raise HTTPException(status_code=404, detail="動画が見つかりません")
+
+    metadata = _refresh_llm_tags(video.video_metadata)
+    video.video_metadata = metadata
+
+    try:
+        db.add(video)
+        db.commit()
+        db.refresh(video)
+    except Exception as e:
+        db.rollback()
+        logger.error("llm タグ再生成失敗: %s", e)
+        raise HTTPException(status_code=500, detail="llm タグ再生成に失敗しました") from e
+
+    return _to_video_tag_read(video.video_metadata)
+
+
+@router.post("/{video_id}/tags/refresh", response_model=VideoTagRead)
+def refresh_video_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTagRead:
+    """Rule/LLM のタグ再生成をまとめて実行する。"""
+    video = db.query(Video).filter(Video.id == video_id).first()
+    if not video:
+        raise HTTPException(status_code=404, detail="動画が見つかりません")
+
+    cfg = get_runtime_settings(db)
+    metadata = _refresh_rule_tags(video, cfg)
+    metadata = _refresh_llm_tags(metadata)
+    video.video_metadata = metadata
+
+    try:
+        db.add(video)
+        db.commit()
+        db.refresh(video)
+    except Exception as e:
+        db.rollback()
+        logger.error("タグ再生成失敗: %s", e)
+        raise HTTPException(status_code=500, detail="タグ再生成に失敗しました") from e
+
+    return _to_video_tag_read(video.video_metadata)
 
 
 @router.get("/{video_id}/timeline", response_model=VideoTimeline)
@@ -221,19 +305,7 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
     cfg = get_runtime_settings(db)
-    rule_tagger = RuleTagger()
-    metadata = normalize_video_metadata(video.video_metadata)
-    metadata["tags_auto_rule"] = rule_tagger.generate(
-        tts_mode=cfg.tts_default_mode,
-        llm_model=cfg.llm_model_name,
-        vlm_model=cfg.vlm_model_name,
-        duration_seconds=video.duration_seconds,
-        fps=video.fps,
-    )
-    tag_status = dict(metadata.get("tag_status", {}))
-    tag_status["rule"] = "ready"
-    metadata["tag_status"] = tag_status
-    video.video_metadata = normalize_video_metadata(metadata)
+    video.video_metadata = _refresh_rule_tags(video, cfg)
     db.add(video)
     db.commit()
 
@@ -660,4 +732,41 @@ def _to_video_read(video: Video) -> VideoRead:
         storage_path=video.storage_path,
         video_metadata=metadata,
         created_at=video.created_at,
+    )
+
+
+def _refresh_rule_tags(video: Video, cfg: Any) -> dict[str, Any]:
+    """RuleTagger で自動タグを更新する。"""
+    rule_tagger = RuleTagger()
+    metadata = normalize_video_metadata(video.video_metadata)
+    metadata["tags_auto_rule"] = rule_tagger.generate(
+        tts_mode=cfg.tts_default_mode,
+        llm_model=cfg.llm_model_name,
+        vlm_model=cfg.vlm_model_name,
+        duration_seconds=video.duration_seconds,
+        fps=video.fps,
+    )
+    tag_status = dict(metadata.get("tag_status", {}))
+    tag_status["rule"] = "ready"
+    metadata["tag_status"] = tag_status
+    return normalize_video_metadata(metadata)
+
+
+def _refresh_llm_tags(raw_metadata: dict[str, Any] | None) -> dict[str, Any]:
+    """LLM タグ更新をスキップし、状態のみ更新する。"""
+    return mark_llm_tag_status_skipped(raw_metadata)
+
+
+def _to_video_tag_read(raw_metadata: dict[str, Any] | None) -> VideoTagRead:
+    """タグ情報の API レスポンスを構築する。"""
+    metadata = normalize_video_metadata(raw_metadata)
+    source_map = build_tag_source_map(metadata)
+    return VideoTagRead(
+        tags_manual=metadata["tags_manual"],
+        tags_auto_rule=metadata["tags_auto_rule"],
+        tags_auto_llm=metadata["tags_auto_llm"],
+        tags_suggested_llm=metadata["tags_suggested_llm"],
+        tags_effective=metadata["tags_effective"],
+        source_by_tag=source_map,
+        tag_status=metadata["tag_status"],
     )

--- a/app/core/tags.py
+++ b/app/core/tags.py
@@ -123,3 +123,31 @@ def _tag_family(tag: str) -> str:
     if len(parts) == 2:
         return parts[0]
     return ":".join(parts[:-1])
+
+
+def build_tag_source_map(metadata: dict[str, Any]) -> dict[str, str]:
+    """タグがどのソース由来かを返す。"""
+    normalized = normalize_video_metadata(metadata)
+    source_map: dict[str, str] = {}
+    for tag in normalized.get("tags_auto_llm", []):
+        source_map[tag] = "llm"
+    for tag in normalized.get("tags_auto_rule", []):
+        source_map[tag] = "rule"
+    for tag in normalized.get("tags_manual", []):
+        source_map[tag] = "manual"
+    for tag in normalized.get("tags_suggested_llm", []):
+        source_map.setdefault(tag, "llm_suggested")
+    return source_map
+
+
+def mark_llm_tag_status_skipped(
+    metadata: dict[str, Any] | None,
+    error_message: str = "LLMTagger 未実装のためスキップしました",
+) -> dict[str, Any]:
+    """LLM タグ更新をスキップ扱いにして状態を返す。"""
+    normalized = normalize_video_metadata(metadata)
+    tag_status = dict(normalized.get("tag_status", {}))
+    tag_status["llm"] = "skipped"
+    tag_status["llm_error"] = error_message
+    normalized["tag_status"] = tag_status
+    return normalize_video_metadata(normalized)

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -26,6 +26,17 @@ class VideoRead(BaseModel):
 class VideoUpdate(BaseModel):
     title: str | None = None
     tags: list[str] | None = None
+    tags_manual: list[str] | None = None
+
+
+class VideoTagRead(BaseModel):
+    tags_manual: list[str]
+    tags_auto_rule: list[str]
+    tags_auto_llm: list[str]
+    tags_suggested_llm: list[str]
+    tags_effective: list[str]
+    source_by_tag: dict[str, str]
+    tag_status: dict[str, str | None]
 
 
 class SegmentRead(BaseModel):

--- a/frontend/src/api/videos.ts
+++ b/frontend/src/api/videos.ts
@@ -1,15 +1,29 @@
 import { api } from './client'
 
+export interface VideoTagStatus {
+  rule: string
+  llm: string
+  llm_error: string | null
+}
+
+export interface VideoMetadata {
+  tags?: string[]
+  tags_manual?: string[]
+  tags_auto_rule?: string[]
+  tags_auto_llm?: string[]
+  tags_suggested_llm?: string[]
+  tags_effective?: string[]
+  tag_status?: VideoTagStatus
+  [key: string]: unknown
+}
+
 export interface Video {
   id: string
   title: string
   duration_seconds: number | null
   fps: number | null
   storage_path: string
-  video_metadata: {
-    tags?: string[]
-    [key: string]: unknown
-  } | null
+  video_metadata: VideoMetadata | null
   created_at: string | null
 }
 
@@ -30,6 +44,7 @@ export async function deleteVideo(id: string): Promise<void> {
 export interface VideoUpdatePayload {
   title?: string
   tags?: string[]
+  tags_manual?: string[]
 }
 
 export async function updateVideo(
@@ -85,5 +100,35 @@ export interface VideoTimeline {
 
 export async function getTimeline(id: string): Promise<VideoTimeline> {
   const { data } = await api.get<VideoTimeline>(`/videos/${id}/timeline`)
+  return data
+}
+
+export interface VideoTagInfo {
+  tags_manual: string[]
+  tags_auto_rule: string[]
+  tags_auto_llm: string[]
+  tags_suggested_llm: string[]
+  tags_effective: string[]
+  source_by_tag: Record<string, string>
+  tag_status: VideoTagStatus
+}
+
+export async function getVideoTags(id: string): Promise<VideoTagInfo> {
+  const { data } = await api.get<VideoTagInfo>(`/videos/${id}/tags`)
+  return data
+}
+
+export async function refreshVideoTags(id: string): Promise<VideoTagInfo> {
+  const { data } = await api.post<VideoTagInfo>(`/videos/${id}/tags/refresh`)
+  return data
+}
+
+export async function refreshVideoRuleTags(id: string): Promise<VideoTagInfo> {
+  const { data } = await api.post<VideoTagInfo>(`/videos/${id}/tags/rule:refresh`)
+  return data
+}
+
+export async function refreshVideoLlmTags(id: string): Promise<VideoTagInfo> {
+  const { data } = await api.post<VideoTagInfo>(`/videos/${id}/tags/llm:refresh`)
   return data
 }

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { MEDIA_BASE } from '../api/client'
-import { deleteVideo, updateVideo, Video } from '../api/videos'
+import {
+  deleteVideo,
+  refreshVideoLlmTags,
+  refreshVideoRuleTags,
+  refreshVideoTags,
+  updateVideo,
+  Video,
+} from '../api/videos'
 
 interface Props {
   videos: Video[]
@@ -15,6 +22,7 @@ export default function VideoList({ videos, onChanged }: Props) {
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [tagInput, setTagInput] = useState('')
   const [tagging, setTagging] = useState(false)
+  const [refreshingTagKey, setRefreshingTagKey] = useState<string | null>(null)
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameInput, setRenameInput] = useState('')
   const [renaming, setRenaming] = useState(false)
@@ -22,24 +30,45 @@ export default function VideoList({ videos, onChanged }: Props) {
     Record<string, boolean>
   >({})
 
+  const effectiveTags = (video: Video): string[] => {
+    if (Array.isArray(video.video_metadata?.tags_effective)) {
+      return video.video_metadata.tags_effective
+    }
+    if (Array.isArray(video.video_metadata?.tags)) {
+      return video.video_metadata.tags
+    }
+    return []
+  }
+
+  const manualTags = (video: Video): string[] => {
+    if (Array.isArray(video.video_metadata?.tags_manual)) {
+      return video.video_metadata.tags_manual
+    }
+    if (Array.isArray(video.video_metadata?.tags)) {
+      return video.video_metadata.tags
+    }
+    return []
+  }
+
+  const suggestedTags = (video: Video): string[] =>
+    Array.isArray(video.video_metadata?.tags_suggested_llm)
+      ? video.video_metadata.tags_suggested_llm
+      : []
+
   const allTags = Array.from(
-    new Set(
-      videos.flatMap((v) => (Array.isArray(v.video_metadata?.tags) ? v.video_metadata.tags : [])),
-    ),
+    new Set(videos.flatMap((v) => effectiveTags(v))),
   ).sort((a, b) => a.localeCompare(b, 'ja'))
 
-  const filtered = videos.filter((v) =>
-    {
-      const tags = Array.isArray(v.video_metadata?.tags) ? v.video_metadata.tags : []
-      const query = search.trim().toLowerCase()
-      const matchSearch =
-        query.length === 0 ||
-        v.title.toLowerCase().includes(query) ||
-        tags.some((t) => t.toLowerCase().includes(query))
-      const matchTag = tagFilter === 'all' || tags.includes(tagFilter)
-      return matchSearch && matchTag
-    },
-  )
+  const filtered = videos.filter((v) => {
+    const tags = effectiveTags(v)
+    const query = search.trim().toLowerCase()
+    const matchSearch =
+      query.length === 0 ||
+      v.title.toLowerCase().includes(query) ||
+      tags.some((t) => t.toLowerCase().includes(query))
+    const matchTag = tagFilter === 'all' || tags.includes(tagFilter)
+    return matchSearch && matchTag
+  })
   const filteredIds = filtered.map((v) => v.id)
   const allFilteredSelected =
     filteredIds.length > 0 && filteredIds.every((id) => selectedIds.has(id))
@@ -132,10 +161,8 @@ export default function VideoList({ videos, onChanged }: Props) {
       await Promise.all(
         targetIds.map(async (id) => {
           const video = videos.find((v) => v.id === id)
-          const current = Array.isArray(video?.video_metadata?.tags)
-            ? video!.video_metadata!.tags!
-            : []
-          await updateVideo(id, { tags: mergeTags(current, newTags) })
+          const current = video ? manualTags(video) : []
+          await updateVideo(id, { tags_manual: mergeTags(current, newTags) })
         }),
       )
       setTagInput('')
@@ -144,6 +171,49 @@ export default function VideoList({ videos, onChanged }: Props) {
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       window.alert(`タグ更新に失敗しました: ${msg}`)
+    } finally {
+      setTagging(false)
+    }
+  }
+
+  const handleRefresh = async (
+    videoId: string,
+    mode: 'all' | 'rule' | 'llm',
+  ) => {
+    const key = `${videoId}:${mode}`
+    setRefreshingTagKey(key)
+    try {
+      if (mode === 'all') {
+        await refreshVideoTags(videoId)
+      } else if (mode === 'rule') {
+        await refreshVideoRuleTags(videoId)
+      } else {
+        await refreshVideoLlmTags(videoId)
+      }
+      onChanged()
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e)
+      window.alert(`タグ再生成に失敗しました: ${msg}`)
+    } finally {
+      setRefreshingTagKey(null)
+    }
+  }
+
+  const handleAcceptSuggested = async (video: Video) => {
+    const suggestions = suggestedTags(video)
+    if (suggestions.length === 0) {
+      window.alert('取り込み可能な候補タグがありません。')
+      return
+    }
+
+    setTagging(true)
+    try {
+      const mergedManual = mergeTags(manualTags(video), suggestions)
+      await updateVideo(video.id, { tags_manual: mergedManual })
+      onChanged()
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e)
+      window.alert(`候補タグ取り込みに失敗しました: ${msg}`)
     } finally {
       setTagging(false)
     }
@@ -269,21 +339,73 @@ export default function VideoList({ videos, onChanged }: Props) {
                     {v.created_at &&
                       ` · ${new Date(v.created_at).toLocaleString('ja-JP')}`}
                   </div>
-                  {Array.isArray(v.video_metadata?.tags) &&
-                    v.video_metadata.tags.length > 0 && (
-                      <div className="flex flex-wrap gap-1 mt-1">
-                        {v.video_metadata.tags.map((tag) => (
-                          <span
-                            key={`${v.id}-${tag}`}
-                            className="px-2 py-0.5 text-[10px] rounded-full bg-gray-100 text-gray-600"
-                          >
-                            {tag}
-                          </span>
-                        ))}
+                  {effectiveTags(v).length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {effectiveTags(v).map((tag) => (
+                        <span
+                          key={`${v.id}-effective-${tag}`}
+                          className="px-2 py-0.5 text-[10px] rounded-full bg-gray-100 text-gray-700"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {suggestedTags(v).length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {suggestedTags(v).map((tag) => (
+                        <span
+                          key={`${v.id}-suggested-${tag}`}
+                          className="px-2 py-0.5 text-[10px] rounded-full bg-amber-100 text-amber-700"
+                        >
+                          候補: {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {typeof v.video_metadata?.tag_status === 'object' &&
+                    typeof v.video_metadata?.tag_status?.llm_error === 'string' &&
+                    v.video_metadata.tag_status.llm_error && (
+                      <div className="text-[10px] text-amber-700 mt-1">
+                        {v.video_metadata.tag_status.llm_error}
                       </div>
                     )}
                 </div>
               </Link>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => handleRefresh(v.id, 'all')}
+                  disabled={refreshingTagKey === `${v.id}:all`}
+                  className="px-2 py-1 text-xs rounded border border-blue-200 text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                >
+                  {refreshingTagKey === `${v.id}:all` ? '再生成中...' : 'タグ再生成'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleRefresh(v.id, 'rule')}
+                  disabled={refreshingTagKey === `${v.id}:rule`}
+                  className="px-2 py-1 text-xs rounded border border-sky-200 text-sky-700 hover:bg-sky-50 disabled:opacity-50"
+                >
+                  Rule
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleRefresh(v.id, 'llm')}
+                  disabled={refreshingTagKey === `${v.id}:llm`}
+                  className="px-2 py-1 text-xs rounded border border-violet-200 text-violet-700 hover:bg-violet-50 disabled:opacity-50"
+                >
+                  LLM
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleAcceptSuggested(v)}
+                  disabled={tagging || suggestedTags(v).length === 0}
+                  className="px-2 py-1 text-xs rounded border border-amber-200 text-amber-700 hover:bg-amber-50 disabled:opacity-50"
+                >
+                  候補採用
+                </button>
+              </div>
               {renamingId === v.id ? (
                 <div className="flex items-center gap-1">
                   <input

--- a/tests/test_core/test_video_tags_api_helpers.py
+++ b/tests/test_core/test_video_tags_api_helpers.py
@@ -1,0 +1,46 @@
+from app.core.tags import (
+    build_tag_source_map,
+    mark_llm_tag_status_skipped,
+    normalize_video_metadata,
+)
+
+
+def test_mark_llm_tag_status_skipped_when_called_sets_skipped_status_and_error() -> None:
+    metadata = {
+        "tags_auto_llm": ["game:zelda"],
+        "tag_status": {"rule": "ready", "llm": "pending", "llm_error": None},
+    }
+
+    refreshed = mark_llm_tag_status_skipped(metadata)
+
+    assert refreshed["tags_auto_llm"] == ["game:zelda"]
+    assert refreshed["tag_status"]["rule"] == "ready"
+    assert refreshed["tag_status"]["llm"] == "skipped"
+    assert refreshed["tag_status"]["llm_error"] == "LLMTagger 未実装のためスキップしました"
+
+
+def test_build_tag_source_map_when_tags_exist_returns_expected_sources() -> None:
+    metadata = {
+        "tags_manual": ["genre:rpg"],
+        "tags_auto_rule": ["cfg:tts_mode:custom_voice"],
+        "tags_auto_llm": ["game:elden_ring"],
+        "tags_suggested_llm": ["candidate:dragon_quest"],
+    }
+
+    source_map = build_tag_source_map(metadata)
+
+    assert source_map["genre:rpg"] == "manual"
+    assert source_map["cfg:tts_mode:custom_voice"] == "rule"
+    assert source_map["game:elden_ring"] == "llm"
+    assert source_map["candidate:dragon_quest"] == "llm_suggested"
+
+
+def test_normalize_video_metadata_when_metadata_is_none_returns_default_structure() -> None:
+    result = normalize_video_metadata(None)
+
+    assert result["tags_manual"] == []
+    assert result["tags_auto_rule"] == []
+    assert result["tags_auto_llm"] == []
+    assert result["tags_suggested_llm"] == []
+    assert result["tags_effective"] == []
+    assert result["tag_status"] == {"rule": "pending", "llm": "pending", "llm_error": None}


### PR DESCRIPTION
## 概要
- タグ運用 API を追加
  - `GET /videos/{id}/tags`
  - `POST /videos/{id}/tags/refresh`
  - `POST /videos/{id}/tags/rule:refresh`
  - `POST /videos/{id}/tags/llm:refresh`
- `PATCH /videos/{id}` を `tags_manual` 更新に対応（既存 `tags` は後方互換で維持）
- UI を `tags_effective` / `tags_suggested_llm` 表示に更新し、再生成・候補採用操作を追加
- タグ由来マップと LLM スキップ状態ヘルパーを追加し、テストを追加

## 関連 Issue
Closes #63

## 確認事項
- [x] 正常系確認
- [x] 異常系確認
- [x] テスト追加（該当時）
- [x] pre-commit 通過
- [ ] frontend build（WSL1 制約で未実行）
