### PR TITLE
feat: LLMTagger 自動実行を実装

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -29,9 +29,9 @@ from app.core.segmentation import FrameExtractor, SegmentationService
 from app.core.subtitle import SubtitleService
 from app.core.tags import (
     build_tag_source_map,
-    mark_llm_tag_status_skipped,
     normalize_video_metadata,
 )
+from app.core.video_tagging import refresh_llm_tags
 from app.core.vision import VisionService
 from app.db.session import get_db
 from app.models.models import (
@@ -211,12 +211,23 @@ def refresh_video_rule_tags(video_id: str, db: Session = Depends(get_db)) -> Vid
 
 @router.post("/{video_id}/tags/llm:refresh", response_model=VideoTagRead)
 def refresh_video_llm_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTagRead:
-    """LLM タグ再生成を実行する（現状は未実装のためスキップ）。"""
+    """LLM タグを再生成する。"""
     video = db.query(Video).filter(Video.id == video_id).first()
     if not video:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
-    metadata = _refresh_llm_tags(video.video_metadata)
+    cfg = get_runtime_settings(db)
+    llm_client = LLMClient(
+        base_url=cfg.llm_api_base,
+        api_key=cfg.llm_api_key,
+        model=cfg.llm_model_name,
+    )
+    metadata = refresh_llm_tags(
+        video_id=str(video.id),
+        video_title=video.title,
+        raw_metadata=video.video_metadata,
+        llm_client=llm_client,
+    )
     video.video_metadata = metadata
 
     try:
@@ -239,8 +250,18 @@ def refresh_video_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTag
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
     cfg = get_runtime_settings(db)
+    llm_client = LLMClient(
+        base_url=cfg.llm_api_base,
+        api_key=cfg.llm_api_key,
+        model=cfg.llm_model_name,
+    )
     metadata = _refresh_rule_tags(video, cfg)
-    metadata = _refresh_llm_tags(metadata)
+    metadata = refresh_llm_tags(
+        video_id=str(video.id),
+        video_title=video.title,
+        raw_metadata=metadata,
+        llm_client=llm_client,
+    )
     video.video_metadata = metadata
 
     try:
@@ -305,7 +326,19 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
     cfg = get_runtime_settings(db)
-    video.video_metadata = _refresh_rule_tags(video, cfg)
+    llm_client = LLMClient(
+        base_url=cfg.llm_api_base,
+        api_key=cfg.llm_api_key,
+        model=cfg.llm_model_name,
+    )
+    metadata = _refresh_rule_tags(video, cfg)
+    metadata = refresh_llm_tags(
+        video_id=str(video.id),
+        video_title=video.title,
+        raw_metadata=metadata,
+        llm_client=llm_client,
+    )
+    video.video_metadata = metadata
     db.add(video)
     db.commit()
 
@@ -330,12 +363,6 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         max_queue_delay_seconds=cfg.planner_max_queue_delay_seconds,
     )
     commentary_service = CommentaryService()
-    llm_client = LLMClient(
-        base_url=cfg.llm_api_base,
-        api_key=cfg.llm_api_key,
-        model=cfg.llm_model_name,
-    )
-
     update_progress(video_id, "segmentation", 0, "動画を分割中...")
     try:
         seg_results = seg_service.execute(video.storage_path, str(video.id))
@@ -750,11 +777,6 @@ def _refresh_rule_tags(video: Video, cfg: Any) -> dict[str, Any]:
     tag_status["rule"] = "ready"
     metadata["tag_status"] = tag_status
     return normalize_video_metadata(metadata)
-
-
-def _refresh_llm_tags(raw_metadata: dict[str, Any] | None) -> dict[str, Any]:
-    """LLM タグ更新をスキップし、状態のみ更新する。"""
-    return mark_llm_tag_status_skipped(raw_metadata)
 
 
 def _to_video_tag_read(raw_metadata: dict[str, Any] | None) -> VideoTagRead:

--- a/app/core/llm_tagger.py
+++ b/app/core/llm_tagger.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+from app.core.tags import normalize_tags
+
+if TYPE_CHECKING:
+    from app.clients.llm_client import LLMClient
+
+_SYSTEM_PROMPT = (
+    "あなたは動画タグ分類アシスタントです。"
+    "与えられたタイトルと既存タグを参考に、次の JSON を必ず返してください。"
+    '{"tags_auto_llm": ["genre:*", "game:*", "topic:*"], "tags_suggested_llm": ["candidate:*"]}'
+    "説明文は不要です。JSON 以外の文字は出力しないでください。"
+)
+
+
+class LLMTagger:
+    """LLM を使って動画タグを生成する。"""
+
+    _SANITIZE_PATTERN = re.compile(r"[^a-z0-9._-]+")
+    _JSON_BLOCK_PATTERN = re.compile(r"```(?:json)?\s*(\{[\s\S]*\})\s*```", re.IGNORECASE)
+    _AUTO_PREFIXES = {"genre", "game", "topic"}
+
+    def generate(
+        self,
+        *,
+        video_title: str,
+        current_tags: list[str],
+        llm_client: LLMClient,
+    ) -> dict[str, list[str]]:
+        """LLM から自動タグと候補タグを生成して返す。"""
+        messages = self._build_messages(video_title, current_tags)
+        result = llm_client.complete(messages)
+        payload = self._parse_json_payload(result.get("text", ""))
+
+        auto_tags = self._normalize_auto_tags(payload.get("tags_auto_llm"))
+        suggested_tags = self._normalize_suggested_tags(payload.get("tags_suggested_llm"))
+        return {
+            "tags_auto_llm": auto_tags,
+            "tags_suggested_llm": suggested_tags,
+        }
+
+    def _build_messages(self, video_title: str, current_tags: list[str]) -> list[dict[str, str]]:
+        tags_text = ", ".join(current_tags) if current_tags else "(なし)"
+        user_prompt = (
+            f"動画タイトル: {video_title or '(未設定)'}\n"
+            f"既存タグ: {tags_text}\n"
+            "JSON 形式のみで返してください。"
+        )
+        return [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ]
+
+    def _parse_json_payload(self, raw_text: str) -> dict[str, Any]:
+        text = raw_text.strip()
+        match = self._JSON_BLOCK_PATTERN.search(text)
+        if match:
+            text = match.group(1)
+
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise ValueError("LLM タグ出力の JSON 解析に失敗しました") from e
+
+        if not isinstance(payload, dict):
+            raise ValueError("LLM タグ出力がオブジェクト形式ではありません")
+        return payload
+
+    def _normalize_auto_tags(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+
+        raw_tags: list[str] = []
+        for raw in value:
+            if not isinstance(raw, str):
+                continue
+            tag = raw.strip().lower()
+            if ":" not in tag:
+                continue
+            prefix, raw_value = tag.split(":", 1)
+            if prefix not in self._AUTO_PREFIXES:
+                continue
+            raw_tags.append(f"{prefix}:{self._sanitize(raw_value)}")
+
+        tags = normalize_tags(raw_tags)
+        return [tag for tag in tags if not tag.startswith("candidate:")]
+
+    def _normalize_suggested_tags(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+
+        candidate_raw: list[str] = []
+        for raw in value:
+            if not isinstance(raw, str):
+                continue
+            tag = raw.strip().lower()
+            if not tag:
+                continue
+            if tag.startswith("candidate:"):
+                _, candidate_value = tag.split(":", 1)
+                candidate_raw.append(f"candidate:{self._sanitize(candidate_value)}")
+                continue
+            if ":" in tag:
+                tag = tag.split(":", 1)[1]
+            candidate_raw.append(f"candidate:{self._sanitize(tag)}")
+
+        tags = normalize_tags(candidate_raw)
+        return [tag for tag in tags if tag.startswith("candidate:")]
+
+    def _sanitize(self, value: str) -> str:
+        sanitized = self._SANITIZE_PATTERN.sub("_", value.strip().lower())
+        return sanitized.strip("_") or "unknown"

--- a/app/core/video_tagging.py
+++ b/app/core/video_tagging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.core.llm_tagger import LLMTagger
+from app.core.tags import normalize_video_metadata
+from app.utils.logging import logger
+
+if TYPE_CHECKING:
+    from app.clients.llm_client import LLMClient
+
+
+def refresh_llm_tags(
+    *,
+    video_id: str,
+    video_title: str,
+    raw_metadata: dict[str, Any] | None,
+    llm_client: LLMClient,
+) -> dict[str, Any]:
+    """LLMTagger で自動タグを更新する。"""
+    metadata = normalize_video_metadata(raw_metadata)
+    tag_status = dict(metadata.get("tag_status", {}))
+
+    try:
+        generated = LLMTagger().generate(
+            video_title=video_title,
+            current_tags=metadata["tags_effective"],
+            llm_client=llm_client,
+        )
+        metadata["tags_auto_llm"] = generated["tags_auto_llm"]
+        metadata["tags_suggested_llm"] = generated["tags_suggested_llm"]
+        tag_status["llm"] = "ready"
+        tag_status["llm_error"] = None
+    except Exception as e:
+        logger.error("LLM タグ更新失敗: video_id=%s error=%s", video_id, e)
+        tag_status["llm"] = "error"
+        tag_status["llm_error"] = str(e)
+
+    metadata["tag_status"] = tag_status
+    return normalize_video_metadata(metadata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ ignore = ["E501", "B008"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 addopts = "-v"
+
+[tool.setuptools.packages.find]
+include = ["app*"]

--- a/tests/test_core/test_llm_tagger.py
+++ b/tests/test_core/test_llm_tagger.py
@@ -1,0 +1,66 @@
+import pytest
+
+from app.core.llm_tagger import LLMTagger
+
+
+class DummyLLMClient:
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self.messages: list[dict[str, str]] = []
+
+    def complete(self, messages: list[dict[str, str]]) -> dict:
+        self.messages = messages
+        return {"text": self._text, "raw": {}}
+
+
+def test_generate_when_json_response_returns_normalized_tags() -> None:
+    client = DummyLLMClient(
+        '{"tags_auto_llm": ["Genre:RPG", "game:Elden Ring", "topic:Boss Fight", '
+        '"candidate:ignored"], "tags_suggested_llm": ["Dragon Quest", '
+        '"candidate:Final Fantasy", "game:Zelda"]}'
+    )
+
+    result = LLMTagger().generate(
+        video_title="Boss Battle",
+        current_tags=["genre:action", "cfg:tts_mode:custom_voice"],
+        llm_client=client,
+    )
+
+    assert result["tags_auto_llm"] == ["genre:rpg", "game:elden_ring", "topic:boss_fight"]
+    assert result["tags_suggested_llm"] == [
+        "candidate:dragon_quest",
+        "candidate:final_fantasy",
+        "candidate:zelda",
+    ]
+    assert any(message["role"] == "system" for message in client.messages)
+    assert any("動画タイトル: Boss Battle" in message["content"] for message in client.messages)
+
+
+def test_generate_when_fenced_json_response_extracts_payload() -> None:
+    client = DummyLLMClient(
+        "```json\n"
+        '{"tags_auto_llm": ["topic:strategy"], "tags_suggested_llm": ["Metaphor ReFantazio"]}'
+        "\n```"
+    )
+
+    result = LLMTagger().generate(
+        video_title="Strategy Guide",
+        current_tags=[],
+        llm_client=client,
+    )
+
+    assert result == {
+        "tags_auto_llm": ["topic:strategy"],
+        "tags_suggested_llm": ["candidate:metaphor_refantazio"],
+    }
+
+
+def test_generate_when_non_json_response_raises_value_error() -> None:
+    client = DummyLLMClient("not-json")
+
+    with pytest.raises(ValueError, match="JSON 解析に失敗"):
+        LLMTagger().generate(
+            video_title="Broken",
+            current_tags=[],
+            llm_client=client,
+        )

--- a/tests/test_core/test_video_tags_api_helpers.py
+++ b/tests/test_core/test_video_tags_api_helpers.py
@@ -1,8 +1,11 @@
+import pytest
+
 from app.core.tags import (
     build_tag_source_map,
     mark_llm_tag_status_skipped,
     normalize_video_metadata,
 )
+from app.core.video_tagging import refresh_llm_tags
 
 
 def test_mark_llm_tag_status_skipped_when_called_sets_skipped_status_and_error() -> None:
@@ -44,3 +47,54 @@ def test_normalize_video_metadata_when_metadata_is_none_returns_default_structur
     assert result["tags_suggested_llm"] == []
     assert result["tags_effective"] == []
     assert result["tag_status"] == {"rule": "pending", "llm": "pending", "llm_error": None}
+
+
+def test_refresh_llm_tags_when_success_sets_ready_and_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_generate(
+        self, *, video_title: str, current_tags: list[str], llm_client: object
+    ) -> dict:
+        assert video_title == "sample"
+        assert "genre:action" in current_tags
+        return {
+            "tags_auto_llm": ["game:elden_ring"],
+            "tags_suggested_llm": ["candidate:dragon_quest"],
+        }
+
+    monkeypatch.setattr("app.core.llm_tagger.LLMTagger.generate", fake_generate)
+    result = refresh_llm_tags(
+        video_id="video-1",
+        video_title="sample",
+        raw_metadata={"tags_manual": ["genre:action"]},
+        llm_client=object(),
+    )
+
+    assert result["tags_auto_llm"] == ["game:elden_ring"]
+    assert result["tags_suggested_llm"] == ["candidate:dragon_quest"]
+    assert result["tag_status"]["llm"] == "ready"
+    assert result["tag_status"]["llm_error"] is None
+
+
+def test_refresh_llm_tags_when_failure_sets_error_and_keeps_existing_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_generate(
+        self, *, video_title: str, current_tags: list[str], llm_client: object
+    ) -> dict:
+        raise RuntimeError("timeout")
+
+    monkeypatch.setattr("app.core.llm_tagger.LLMTagger.generate", fake_generate)
+    result = refresh_llm_tags(
+        video_id="video-2",
+        video_title="sample",
+        raw_metadata={
+            "tags_auto_llm": ["game:street_fighter"],
+            "tags_suggested_llm": ["candidate:tekken"],
+            "tag_status": {"rule": "ready", "llm": "pending", "llm_error": None},
+        },
+        llm_client=object(),
+    )
+
+    assert result["tags_auto_llm"] == ["game:street_fighter"]
+    assert result["tags_suggested_llm"] == ["candidate:tekken"]
+    assert result["tag_status"]["llm"] == "error"
+    assert result["tag_status"]["llm_error"] == "timeout"


### PR DESCRIPTION
## 概要
- `LLMTagger` を追加し、LLM応答JSONから `tags_auto_llm` / `tags_suggested_llm` を正規化して生成
- `refresh_llm_tags` ヘルパーを追加し、失敗時は `tag_status.llm=error` と `llm_error` を保持して処理継続
- `/videos/{id}/tags/llm:refresh`・`/videos/{id}/tags/refresh`・`/videos/{id}/process` で LLMタグ更新を実行
- LLMタグ生成とAPIヘルパーのテストを追加
- `pyproject.toml` に setuptools の package find 設定を追加し、editable install を安定化

## 関連 Issue
Closes #62

## 確認事項
- [x] 正常系確認
- [x] 異常系確認
- [x] テスト追加（該当時）
- [x] pre-commit 通過
