### PR TITLE
docs: startスキルで全phaseのOpen Issueを初回取得

### DIFF
--- a/.codex/skills/start/SKILL.md
+++ b/.codex/skills/start/SKILL.md
@@ -24,12 +24,13 @@ description: 作業開始時に GitHub Issues を確認し、ブランチ作成�
    - `sudo` が必要なインストールや認証操作は、必ずユーザーに実行を依頼する
    - ユーザーの確認なしに API フォールバックや別経路で先に進めない
 
-1. Open な Issue 一覧を取得する
+1. Open な Issue 一覧を取得する（`phase:mvp` 以外も含む）
    ```bash
-   gh issue list --repo sora-kisaragi/aituber --state open --label "phase:mvp"
+   gh issue list --repo sora-kisaragi/aituber --state open --limit 100 \
+     --search 'label:"phase:mvp" OR label:"phase:quality" OR label:"phase:ops"'
    ```
 
-2. ラベル・番号を確認して作業候補を提示する
+2. フェーズラベル（`phase:mvp` / `phase:quality` / `phase:ops`）と番号を確認して作業候補を提示する
 
 3. ユーザーが取り掛かる Issue を選ぶ
 


### PR DESCRIPTION
## 概要
- `start` スキルの Issue 取得対象を `phase:mvp` 固定から、`phase:quality` / `phase:ops` を含む検索に変更
- 手順2の説明を3フェーズ確認前提に更新

## 関連 Issue
- N/A

## 確認事項
- [x] 正常系確認
- [ ] 異常系確認
- [ ] テスト追加（該当時）
- [x] pre-commit 通過
