### PR TITLE
chore: update ship skill for issue-less PR template

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -59,14 +59,16 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    git push origin <current-branch>
    ```
 
-4. PR を作成する（関連 Issue があれば `Closes #XX` を含める）
+4. PR を作成する（関連 Issue があれば `Closes #XX` を含め、なければ `N/A` を明記する）
    ```powershell
    @'
    ## 概要
    <変更内容>
 
    ## 関連 Issue
-   Closes #<Issue番号>
+   <関連Issue行>
+   # 例1: Closes #<Issue番号>
+   # 例2: N/A（関連Issueなし）
 
    ## 確認事項
    - [ ] 正常系確認

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -59,14 +59,16 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    git push origin <current-branch>
    ```
 
-4. PR を作成する（関連 Issue があれば `Closes #XX` を含める）
+4. PR を作成する（関連 Issue があれば `Closes #XX` を含め、なければ `N/A` を明記する）
    ```powershell
    @'
    ## 概要
    <変更内容>
 
    ## 関連 Issue
-   Closes #<Issue番号>
+   <関連Issue行>
+   # 例1: Closes #<Issue番号>
+   # 例2: N/A（関連Issueなし）
 
    ## 確認事項
    - [ ] 正常系確認


### PR DESCRIPTION
## 概要
- `ship` スキルに「関連Issueがない場合は `N/A` を明記する」ルールを追加
- PR 本文テンプレートに `Closes #<Issue番号>` / `N/A（関連Issueなし）` の両例を追記
- `.codex` と `.claude` の `ship` を同期更新

## 関連 Issue
N/A

## 確認事項
- [x] 正常系確認
- [ ] 異常系確認
- [ ] テスト追加（該当時）
- [x] pre-commit 通過
