### PR TITLE
chore: refine ship skill flow for committed changes

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -47,6 +47,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    git diff --stat
    pre-commit run --all-files
    ```
+   - すでに対象コミットを作成済みで作業ツリーが clean の場合は、手順2をスキップして手順3へ進む
 
 2. ステージングとコミット
    ```bash
@@ -87,7 +88,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    if git ls-remote --exit-code --heads origin <作業ブランチ> >/dev/null 2>&1; then
      git push origin --delete <作業ブランチ>
    fi
-   git worktree remove --force /tmp/<repo>-ship
+   git worktree remove --force /tmp/<repo>-ship || true
    ```
 
 - 方針: PR マージ後は、不要になったブランチを削除して `main` に戻した状態を作業の終了条件にする

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -47,6 +47,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    git diff --stat
    pre-commit run --all-files
    ```
+   - すでに対象コミットを作成済みで作業ツリーが clean の場合は、手順2をスキップして手順3へ進む
 
 2. ステージングとコミット
    ```bash
@@ -87,7 +88,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    if git ls-remote --exit-code --heads origin <作業ブランチ> >/dev/null 2>&1; then
      git push origin --delete <作業ブランチ>
    fi
-   git worktree remove --force /tmp/<repo>-ship
+   git worktree remove --force /tmp/<repo>-ship || true
    ```
 
 - 方針: PR マージ後は、不要になったブランチを削除して `main` に戻した状態を作業の終了条件にする


### PR DESCRIPTION
## 概要
- `ship` スキルの手順を改善し、対象コミット済みかつ clean な場合は手順2（再コミット）をスキップ可能にした
- `worktree` 未使用時でも後処理で失敗しないよう `git worktree remove ... || true` に調整した
- `.codex` と `.claude` の `ship` スキルを同期更新した

## 関連 Issue
N/A

## 確認事項
- [x] 正常系確認
- [ ] 異常系確認
- [ ] テスト追加（該当時）
- [x] pre-commit 通過
