### PR TITLE
feat: add pipeline debug artifacts and segment logs

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -45,7 +45,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    ```bash
    git status
    git diff --stat
-   pre-commit run --all-files
+   .venv/bin/pre-commit run --all-files
    ```
    - すでに対象コミットを作成済みで作業ツリーが clean の場合は、手順2をスキップして手順3へ進む
 

--- a/.claude/skills/test-check/SKILL.md
+++ b/.claude/skills/test-check/SKILL.md
@@ -19,9 +19,9 @@ description: 実装完了判定チェックリストを実行し、テスト記�
 
 以下をすべて満たすまで「完了」としない。
 
-- [ ] `pytest` が通過する
-- [ ] `ruff check` エラーなし
-- [ ] `ruff format --check` で差分なし
+- [ ] `.venv/bin/pytest` が通過する
+- [ ] `.venv/bin/ruff check` エラーなし
+- [ ] `.venv/bin/ruff format --check` で差分なし
 - [ ] 正常系が確認されている
 - [ ] 異常系が確認されている（不正入力・外部 API エラー）
 - [ ] ログで問題を切り分け可能である

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -45,7 +45,7 @@ description: 現在のブランチの変更をコミット → push → PR 作�
    ```bash
    git status
    git diff --stat
-   pre-commit run --all-files
+   .venv/bin/pre-commit run --all-files
    ```
    - すでに対象コミットを作成済みで作業ツリーが clean の場合は、手順2をスキップして手順3へ進む
 

--- a/.codex/skills/ship/agents/openai.yaml
+++ b/.codex/skills/ship/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Ship (Commit → Push → PR)"
   short_description: "変更をコミット・push して PR を作成する一連操作"
-  default_prompt: "現在のブランチの変更を確認し、pre-commit を実行後、コミット・push・PR 作成まで一括で行う。コミットメッセージが未指定の場合は変更内容から適切なメッセージを提案する。実行後は感想・使い勝手・改善提案を確認し、更新する場合は /update-skill ship を案内する。"
+  default_prompt: "現在のブランチの変更を確認し、.venv/bin/pre-commit を実行後、コミット・push・PR 作成まで一括で行う。コミットメッセージが未指定の場合は変更内容から適切なメッセージを提案する。実行後は感想・使い勝手・改善提案を確認し、更新する場合は /update-skill ship を案内する。"

--- a/.codex/skills/test-check/SKILL.md
+++ b/.codex/skills/test-check/SKILL.md
@@ -19,9 +19,9 @@ description: 実装完了判定チェックリストを実行し、テスト記�
 
 以下をすべて満たすまで「完了」としない。
 
-- [ ] `pytest` が通過する
-- [ ] `ruff check` エラーなし
-- [ ] `ruff format --check` で差分なし
+- [ ] `.venv/bin/pytest` が通過する
+- [ ] `.venv/bin/ruff check` エラーなし
+- [ ] `.venv/bin/ruff format --check` で差分なし
 - [ ] 正常系が確認されている
 - [ ] 異常系が確認されている
 - [ ] ログで問題を切り分け可能である

--- a/.codex/skills/test-check/agents/openai.yaml
+++ b/.codex/skills/test-check/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Test Check"
   short_description: "実装完了判定チェックリストを実行"
-  default_prompt: "指定された機能について実装完了チェックリストを実行し、pytest 実行結果・正常系・異常系の確認状況を報告する。未確認項目があれば具体的なテストケースを提案する。実行後は感想・使い勝手・改善提案を確認し、更新する場合は /update-skill test-check を案内する。"
+  default_prompt: "指定された機能について実装完了チェックリストを実行し、.venv/bin/pytest 実行結果・正常系・異常系の確認状況を報告する。未確認項目があれば具体的なテストケースを提案する。実行後は感想・使い勝手・改善提案を確認し、更新する場合は /update-skill test-check を案内する。"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,14 @@ FastAPI + PostgreSQL + Qwen TTS + LLM API で構成する Python バックエン
 ## セットアップ
 
 ```bash
+# 仮想環境作成
+python3 -m venv .venv
+
 # 依存関係インストール
-pip install -e ".[dev]"
+.venv/bin/python -m pip install -e ".[dev]"
 
 # pre-commit フック設定
-pre-commit install
+.venv/bin/pre-commit install
 
 # 環境変数設定
 cp .env.example .env
@@ -29,10 +32,10 @@ cp .env.example .env
 docker compose -f docker/docker-compose.yml up -d db redis
 
 # マイグレーション
-alembic upgrade head
+.venv/bin/alembic upgrade head
 
 # サーバー起動
-uvicorn app.main:app --reload
+.venv/bin/uvicorn app.main:app --reload
 ```
 
 ---
@@ -41,21 +44,21 @@ uvicorn app.main:app --reload
 
 ```bash
 # テスト実行
-pytest tests/ -v
+.venv/bin/pytest tests/ -v
 
 # Lint / フォーマット
-ruff check .
-ruff format .
+.venv/bin/ruff check .
+.venv/bin/ruff format .
 
 # pre-commit 全実行
-pre-commit run --all-files
+.venv/bin/pre-commit run --all-files
 
 # マイグレーション生成
-alembic revision --autogenerate -m "説明"
-alembic upgrade head
+.venv/bin/alembic revision --autogenerate -m "説明"
+.venv/bin/alembic upgrade head
 
 # パイプライン一括実行（開発用）
-python scripts/run_pipeline.py --input sample_data/videos/sample_match.mp4
+.venv/bin/python scripts/run_pipeline.py --input sample_data/videos/sample_match.mp4
 ```
 
 ---
@@ -141,7 +144,7 @@ mp4 入力
 - 外部依存（DB・外部 API）は `pytest-mock` でモック化
 - 正常系・異常系の両方を必ずカバーする
 - テスト名: `test_<対象>_<条件>_<期待結果>`
-- PR 前に `pre-commit run --all-files` と `pytest` を実行する
+- PR 前に `.venv/bin/pre-commit run --all-files` と `.venv/bin/pytest` を実行する
 
 ---
 

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -46,6 +46,7 @@ from app.models.models import (
 )
 from app.models.schemas import TimelineItem, VideoRead, VideoTagRead, VideoTimeline, VideoUpdate
 from app.utils.logging import logger
+from app.utils.pipeline_debug import PipelineDebugRecorder
 
 router = APIRouter()
 
@@ -326,11 +327,13 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
     cfg = get_runtime_settings(db)
+    debug_recorder = PipelineDebugRecorder(cfg.media_root, str(video.id))
     llm_client = LLMClient(
         base_url=cfg.llm_api_base,
         api_key=cfg.llm_api_key,
         model=cfg.llm_model_name,
     )
+    original_metadata = video.video_metadata
     metadata = _refresh_rule_tags(video, cfg)
     metadata = refresh_llm_tags(
         video_id=str(video.id),
@@ -341,6 +344,15 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     video.video_metadata = metadata
     db.add(video)
     db.commit()
+    debug_recorder.save_step_io(
+        "tag_refresh",
+        input_data={
+            "video_id": str(video.id),
+            "title": video.title,
+            "video_metadata": original_metadata,
+        },
+        output_data={"video_metadata": metadata},
+    )
 
     seg_service = SegmentationService(
         segment_duration=cfg.segment_duration,
@@ -374,12 +386,42 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         logger.error("process エラー: %s", e)
         raise HTTPException(status_code=500, detail=str(e)) from e
     logger.info("分割完了: %d セグメント", len(seg_results))
+    debug_recorder.save_step_io(
+        "segmentation",
+        input_data={
+            "video_id": str(video.id),
+            "storage_path": video.storage_path,
+            "segment_duration": cfg.segment_duration,
+        },
+        output_data={
+            "segment_count": len(seg_results),
+            "segments": [
+                {
+                    "index": idx,
+                    "start_time": seg.start_time,
+                    "end_time": seg.end_time,
+                    "segment_type": seg.segment_type,
+                    "storage_path": seg.storage_path,
+                }
+                for idx, seg in enumerate(seg_results)
+            ],
+        },
+    )
     update_progress(video_id, "segmentation", 10, f"分割完了: {len(seg_results)} セグメント")
 
     all_events = []
+    segment_debug_summaries: list[dict[str, Any]] = []
     seg_count = len(seg_results)
 
     for seg_idx, seg_result in enumerate(seg_results):
+        logger.debug(
+            "segment処理開始: video_id=%s index=%d/%d range=%.2f-%.2f",
+            video_id,
+            seg_idx + 1,
+            seg_count,
+            seg_result.start_time,
+            seg_result.end_time,
+        )
         segment = Segment(
             video_id=video.id,
             start_time=seg_result.start_time,
@@ -389,6 +431,17 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         )
         db.add(segment)
         db.flush()
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="segment_init",
+            input_data={
+                "start_time": seg_result.start_time,
+                "end_time": seg_result.end_time,
+                "segment_type": seg_result.segment_type,
+            },
+            output_data={"segment_storage_path": seg_result.storage_path},
+        )
 
         frame_results = frame_extractor.extract(
             video.storage_path,
@@ -396,23 +449,60 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             seg_result.start_time,
             seg_result.end_time,
         )
+        frame_debug_rows = [
+            {"timestamp": fr.timestamp, "image_path": fr.image_path} for fr in frame_results
+        ]
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="frame_extraction",
+            input_data={
+                "video_path": video.storage_path,
+                "start_time": seg_result.start_time,
+                "end_time": seg_result.end_time,
+            },
+            output_data={
+                "frame_count": len(frame_results),
+                "frames": frame_debug_rows,
+            },
+        )
 
         analyses = []
+        analysis_debug_rows: list[dict[str, Any]] = []
         for fr in frame_results:
             analysis = vision_service.analyze_frame(fr.image_path, vlm_client)
+            features = vision_service.to_dict(analysis)
             frame = Frame(
                 segment_id=segment.id,
                 timestamp=fr.timestamp,
                 image_path=fr.image_path,
-                features=vision_service.to_dict(analysis),
+                features=features,
             )
             db.add(frame)
             analyses.append(analysis)
+            analysis_debug_rows.append(
+                {
+                    "timestamp": fr.timestamp,
+                    "image_path": fr.image_path,
+                    "analysis": features,
+                }
+            )
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="vision_analysis",
+            input_data={"frame_count": len(frame_results)},
+            output_data={
+                "analysis_count": len(analysis_debug_rows),
+                "analyses": analysis_debug_rows,
+            },
+        )
 
         pct = 10 + int((seg_idx + 1) / seg_count * 60)
         update_progress(video_id, "vision", pct, f"フレーム解析中: {seg_idx + 1}/{seg_count}")
 
         event_results = event_service.generate(str(segment.id), seg_result.start_time, analyses)
+        event_debug_rows: list[dict[str, Any]] = []
         for er in event_results:
             event = Event(
                 segment_id=segment.id,
@@ -423,14 +513,83 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             )
             db.add(event)
             all_events.append(er)
+            event_debug_rows.append(
+                {
+                    "event_id": er.event_id,
+                    "timestamp": er.timestamp,
+                    "event_type": er.event_type,
+                    "importance": er.importance,
+                    "emotion_hint": er.emotion_hint,
+                    "speak_recommended": er.speak_recommended,
+                    "details": er.details,
+                }
+            )
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="event_generation",
+            input_data={
+                "analysis_count": len(analysis_debug_rows),
+                "segment_start_time": seg_result.start_time,
+            },
+            output_data={
+                "event_count": len(event_debug_rows),
+                "events": event_debug_rows,
+            },
+        )
+        segment_debug_summaries.append(
+            {
+                "segment_index": seg_idx,
+                "segment_id": str(segment.id),
+                "start_time": seg_result.start_time,
+                "end_time": seg_result.end_time,
+                "frame_count": len(frame_results),
+                "analysis_count": len(analysis_debug_rows),
+                "event_count": len(event_debug_rows),
+            }
+        )
+        logger.debug(
+            "segment処理完了: video_id=%s segment_id=%s frames=%d events=%d",
+            video_id,
+            segment.id,
+            len(frame_results),
+            len(event_debug_rows),
+        )
 
     db.commit()
+    debug_recorder.save_step_io(
+        "segment_pipeline",
+        input_data={"segment_count": seg_count},
+        output_data={
+            "total_event_count": len(all_events),
+            "segments": segment_debug_summaries,
+        },
+    )
     update_progress(video_id, "planning", 75, "発話計画を生成中...")
 
     plan_results = planner.plan(str(video.id), all_events)
+    debug_recorder.save_step_io(
+        "planning",
+        input_data={"event_count": len(all_events)},
+        output_data={
+            "plan_count": len(plan_results),
+            "plans": [
+                {
+                    "plan_id": pr.plan_id,
+                    "event_ids": pr.event_ids,
+                    "start_time": pr.start_time,
+                    "end_time": pr.end_time,
+                    "priority": pr.priority,
+                    "style": pr.style,
+                }
+                for pr in plan_results
+            ],
+        },
+    )
     update_progress(video_id, "planning", 80, f"発話計画完了: {len(plan_results)} 件")
     prev_text = ""
     plan_count = len(plan_results)
+    commentary_debug_rows: list[dict[str, Any]] = []
     for plan_idx, pr in enumerate(plan_results):
         plan = UtterancePlan(
             video_id=video.id,
@@ -453,13 +612,37 @@ def process_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             llm_raw_response=com_data["llm_raw_response"],
         )
         db.add(commentary)
+        commentary_debug_rows.append(
+            {
+                "index": plan_idx,
+                "plan_id": str(plan.id),
+                "event_ids": pr.event_ids,
+                "style": com_data["style"],
+                "text": com_data["text"],
+                "language": com_data["language"],
+            }
+        )
         pct = 80 + int((plan_idx + 1) / plan_count * 15)
         update_progress(video_id, "commentary", pct, f"実況生成中: {plan_idx + 1}/{plan_count}")
         prev_text = com_data["text"]
 
     db.commit()
+    debug_recorder.save_step_io(
+        "commentary_generation",
+        input_data={"plan_count": plan_count},
+        output_data={
+            "commentary_count": len(commentary_debug_rows),
+            "commentaries": commentary_debug_rows,
+        },
+    )
     update_progress(video_id, "done", 100, "処理完了")
-    return {"status": "ok", "video_id": video_id, "plans": len(plan_results)}
+    result = {"status": "ok", "video_id": video_id, "plans": len(plan_results)}
+    debug_recorder.save_step_io(
+        "process_result",
+        input_data={"video_id": video_id},
+        output_data=result,
+    )
+    return result
 
 
 @router.post("/{video_id}/compose")
@@ -470,6 +653,7 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         raise HTTPException(status_code=404, detail="動画が見つかりません")
 
     cfg = get_runtime_settings(db)
+    debug_recorder = PipelineDebugRecorder(cfg.media_root, str(video.id))
 
     tts_client = QwenTTSClient(
         base_url=cfg.tts_base_url,
@@ -491,6 +675,9 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     pending_entries: list[tuple[UtterancePlan, Commentary, AudioEntry]] = []
     audio_entries: list[AudioEntry] = []
     srt_paths: list[str] = []
+    tts_debug_rows: list[dict[str, Any]] = []
+    subtitle_debug_rows: list[dict[str, Any]] = []
+    schedule_debug_rows: list[dict[str, Any]] = []
     plan_count = len(plans)
     update_progress(video_id, "compose", 0, "音声合成を開始...")
 
@@ -507,6 +694,16 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             audio_path = str(Path(cfg.media_root) / str(commentary.id) / "audio.wav")
             instruct = _STYLE_INSTRUCT.get(commentary.style or "", "")
             duration = tts_client.synthesize(commentary.text, audio_path, instruct=instruct)
+            tts_debug_rows.append(
+                {
+                    "index": plan_idx,
+                    "plan_id": str(plan.id),
+                    "commentary_id": str(commentary.id),
+                    "style": commentary.style,
+                    "audio_path": audio_path,
+                    "duration_seconds": duration,
+                }
+            )
 
             audio = Audio(
                 commentary_id=commentary.id,
@@ -534,6 +731,15 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
 
         for index, (plan, commentary, _) in enumerate(pending_entries):
             normalized = normalized_entries[index]
+            schedule_debug_rows.append(
+                {
+                    "index": index,
+                    "plan_id": str(plan.id),
+                    "old_start_time": plan.start_time,
+                    "new_start_time": normalized.start_time,
+                    "duration_seconds": normalized.duration_seconds,
+                }
+            )
             if abs(normalized.start_time - plan.start_time) > 1e-6:
                 logger.info(
                     "発話開始時刻を調整: plan_id=%s old=%.3f new=%.3f",
@@ -559,6 +765,15 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
                 end_time=srt_result.end_time,
             )
             db.add(subtitle)
+            subtitle_debug_rows.append(
+                {
+                    "index": index,
+                    "commentary_id": str(commentary.id),
+                    "file_path": srt_result.file_path,
+                    "start_time": srt_result.start_time,
+                    "end_time": srt_result.end_time,
+                }
+            )
             audio_entries.append(
                 AudioEntry(
                     audio_path=normalized.audio_path,
@@ -569,6 +784,21 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             srt_paths.append(srt_result.file_path)
 
         db.commit()
+        debug_recorder.save_step_io(
+            "tts_and_subtitle",
+            input_data={
+                "plan_count": plan_count,
+                "overlap_min_gap_seconds": cfg.compose_overlap_min_gap_seconds,
+            },
+            output_data={
+                "tts_count": len(tts_debug_rows),
+                "subtitle_count": len(subtitle_debug_rows),
+                "schedule_count": len(schedule_debug_rows),
+                "tts_items": tts_debug_rows,
+                "schedule_items": schedule_debug_rows,
+                "subtitle_items": subtitle_debug_rows,
+            },
+        )
 
         update_progress(video_id, "compose", 85, "字幕・動画を合成準備中...")
         update_progress(video_id, "compose", 88, "字幕ファイルを結合中...")
@@ -576,6 +806,16 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         update_progress(video_id, "compose", 92, "映像・音声を合成中（FFmpeg）...")
         output_path = str(Path(cfg.media_root) / str(video_id) / "output.mp4")
         composer.compose(video.storage_path, audio_entries, merged_srt, output_path)
+        debug_recorder.save_step_io(
+            "compose",
+            input_data={
+                "video_id": video_id,
+                "input_video": video.storage_path,
+                "audio_count": len(audio_entries),
+                "merged_srt": merged_srt,
+            },
+            output_data={"output_path": output_path},
+        )
         update_progress(video_id, "compose", 98, "最終処理中...")
 
     except subprocess.CalledProcessError as e:

--- a/app/utils/pipeline_debug.py
+++ b/app/utils/pipeline_debug.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, is_dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from app.utils.logging import logger
+
+
+class PipelineDebugRecorder:
+    """パイプラインの入出力とデバッグ情報をファイルへ保存する。"""
+
+    def __init__(self, media_root: str, video_id: str) -> None:
+        self.video_id = video_id
+        self.debug_dir = Path(media_root) / video_id / "debug"
+        self.steps_dir = self.debug_dir / "steps"
+        self.segment_log_path = self.debug_dir / "segments_debug.jsonl"
+        self.steps_dir.mkdir(parents=True, exist_ok=True)
+        self._step_index = 0
+
+    def save_step_io(
+        self,
+        step_name: str,
+        input_data: dict[str, Any],
+        output_data: dict[str, Any],
+    ) -> str | None:
+        """ステップ入出力を JSON ファイルとして保存する。"""
+        self._step_index += 1
+        file_name = f"{self._step_index:02d}_{_sanitize_step_name(step_name)}.json"
+        output_path = self.steps_dir / file_name
+        payload = {
+            "video_id": self.video_id,
+            "step": step_name,
+            "recorded_at": datetime.now(tz=UTC).isoformat(),
+            "input": _to_jsonable(input_data),
+            "output": _to_jsonable(output_data),
+        }
+        return self._write_json_file(output_path, payload, label=f"step={step_name}")
+
+    def append_segment_debug(
+        self,
+        segment_index: int,
+        segment_id: str,
+        stage: str,
+        input_data: dict[str, Any],
+        output_data: dict[str, Any],
+    ) -> str | None:
+        """セグメント単位のデバッグ情報を JSONL 形式で追記する。"""
+        payload = {
+            "video_id": self.video_id,
+            "segment_index": segment_index,
+            "segment_id": segment_id,
+            "stage": stage,
+            "recorded_at": datetime.now(tz=UTC).isoformat(),
+            "input": _to_jsonable(input_data),
+            "output": _to_jsonable(output_data),
+        }
+        try:
+            with open(self.segment_log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(payload, ensure_ascii=False))
+                f.write("\n")
+        except Exception as e:
+            logger.error("segment デバッグログ保存失敗(%s): %s", stage, e)
+            return None
+        logger.debug(
+            "segment デバッグログ保存: stage=%s segment=%s path=%s",
+            stage,
+            segment_id,
+            self.segment_log_path,
+        )
+        return str(self.segment_log_path)
+
+    def _write_json_file(
+        self, output_path: Path, payload: dict[str, Any], label: str
+    ) -> str | None:
+        try:
+            output_path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except Exception as e:
+            logger.error("デバッグ入出力保存失敗(%s): %s", label, e)
+            return None
+        logger.debug("デバッグ入出力保存: %s", output_path)
+        return str(output_path)
+
+
+def _sanitize_step_name(step_name: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_-]+", "_", step_name).strip("_")
+    return normalized or "step"
+
+
+def _to_jsonable(value: Any) -> Any:
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+    if isinstance(value, Path | UUID):
+        return str(value)
+    if is_dataclass(value):
+        return _to_jsonable(asdict(value))
+    if isinstance(value, dict):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_to_jsonable(v) for v in value]
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _to_jsonable(model_dump())
+        except Exception:
+            return repr(value)
+
+    to_dict = getattr(value, "dict", None)
+    if callable(to_dict):
+        try:
+            return _to_jsonable(to_dict())
+        except Exception:
+            return repr(value)
+
+    if hasattr(value, "__dict__"):
+        try:
+            return _to_jsonable(vars(value))
+        except Exception:
+            return repr(value)
+
+    return repr(value)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 import uuid
 from pathlib import Path
+from typing import Any
 
 # プロジェクトルートを sys.path に追加
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -40,6 +41,7 @@ from app.models.models import (
     Video,
 )
 from app.utils.logging import logger
+from app.utils.pipeline_debug import PipelineDebugRecorder
 
 
 def probe_video_meta(video_path: str) -> tuple[float, float]:
@@ -81,6 +83,20 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
     )
     db.add(video)
     db.commit()
+    debug_recorder = PipelineDebugRecorder(settings.media_root, str(video_id))
+    debug_recorder.save_step_io(
+        "video_registration",
+        input_data={
+            "input_path": input_path,
+            "title": title,
+        },
+        output_data={
+            "video_id": str(video_id),
+            "storage_path": str(dest_path),
+            "duration_seconds": duration,
+            "fps": fps,
+        },
+    )
     logger.info("動画登録完了: video_id=%s duration=%.1fs", video_id, duration)
 
     # ── 動画分割 ──────────────────────────────────────────────────────────────
@@ -89,6 +105,26 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
         media_root=settings.media_root,
     )
     seg_results = seg_service.execute(str(dest_path), str(video_id))
+    debug_recorder.save_step_io(
+        "segmentation",
+        input_data={
+            "video_path": str(dest_path),
+            "segment_duration": settings.segment_duration,
+        },
+        output_data={
+            "segment_count": len(seg_results),
+            "segments": [
+                {
+                    "index": idx,
+                    "start_time": seg.start_time,
+                    "end_time": seg.end_time,
+                    "segment_type": seg.segment_type,
+                    "storage_path": seg.storage_path,
+                }
+                for idx, seg in enumerate(seg_results)
+            ],
+        },
+    )
     logger.info("分割完了: %d セグメント", len(seg_results))
 
     # ── フレーム抽出・VLM 解析・イベント生成 ──────────────────────────────────
@@ -97,8 +133,17 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
     event_service = EventService()
 
     all_event_results = []
+    segment_debug_summaries: list[dict[str, Any]] = []
 
-    for seg_result in seg_results:
+    for seg_idx, seg_result in enumerate(seg_results):
+        logger.debug(
+            "segment処理開始: video_id=%s index=%d/%d range=%.2f-%.2f",
+            video_id,
+            seg_idx + 1,
+            len(seg_results),
+            seg_result.start_time,
+            seg_result.end_time,
+        )
         segment = Segment(
             video_id=video.id,
             start_time=seg_result.start_time,
@@ -108,6 +153,17 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
         )
         db.add(segment)
         db.flush()
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="segment_init",
+            input_data={
+                "start_time": seg_result.start_time,
+                "end_time": seg_result.end_time,
+                "segment_type": seg_result.segment_type,
+            },
+            output_data={"segment_storage_path": seg_result.storage_path},
+        )
 
         frame_results = frame_extractor.extract(
             str(dest_path),
@@ -115,20 +171,57 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
             seg_result.start_time,
             seg_result.end_time,
         )
+        frame_debug_rows = [
+            {"timestamp": fr.timestamp, "image_path": fr.image_path} for fr in frame_results
+        ]
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="frame_extraction",
+            input_data={
+                "video_path": str(dest_path),
+                "start_time": seg_result.start_time,
+                "end_time": seg_result.end_time,
+            },
+            output_data={
+                "frame_count": len(frame_results),
+                "frames": frame_debug_rows,
+            },
+        )
 
         analyses = []
+        analysis_debug_rows: list[dict[str, Any]] = []
         for fr in frame_results:
             analysis = vision_service.analyze_frame(fr.image_path)
+            features = vision_service.to_dict(analysis)
             frame = Frame(
                 segment_id=segment.id,
                 timestamp=fr.timestamp,
                 image_path=fr.image_path,
-                features=vision_service.to_dict(analysis),
+                features=features,
             )
             db.add(frame)
             analyses.append(analysis)
+            analysis_debug_rows.append(
+                {
+                    "timestamp": fr.timestamp,
+                    "image_path": fr.image_path,
+                    "analysis": features,
+                }
+            )
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="vision_analysis",
+            input_data={"frame_count": len(frame_results)},
+            output_data={
+                "analysis_count": len(analysis_debug_rows),
+                "analyses": analysis_debug_rows,
+            },
+        )
 
         event_results = event_service.generate(str(segment.id), seg_result.start_time, analyses)
+        event_debug_rows: list[dict[str, Any]] = []
         for er in event_results:
             event = Event(
                 segment_id=segment.id,
@@ -138,14 +231,82 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
                 details=er.details,
             )
             db.add(event)
+            event_debug_rows.append(
+                {
+                    "event_id": er.event_id,
+                    "timestamp": er.timestamp,
+                    "event_type": er.event_type,
+                    "importance": er.importance,
+                    "emotion_hint": er.emotion_hint,
+                    "speak_recommended": er.speak_recommended,
+                    "details": er.details,
+                }
+            )
+        debug_recorder.append_segment_debug(
+            segment_index=seg_idx,
+            segment_id=str(segment.id),
+            stage="event_generation",
+            input_data={
+                "analysis_count": len(analysis_debug_rows),
+                "segment_start_time": seg_result.start_time,
+            },
+            output_data={
+                "event_count": len(event_debug_rows),
+                "events": event_debug_rows,
+            },
+        )
+        segment_debug_summaries.append(
+            {
+                "segment_index": seg_idx,
+                "segment_id": str(segment.id),
+                "start_time": seg_result.start_time,
+                "end_time": seg_result.end_time,
+                "frame_count": len(frame_results),
+                "analysis_count": len(analysis_debug_rows),
+                "event_count": len(event_debug_rows),
+            }
+        )
+        logger.debug(
+            "segment処理完了: video_id=%s segment_id=%s frames=%d events=%d",
+            video_id,
+            segment.id,
+            len(frame_results),
+            len(event_debug_rows),
+        )
         all_event_results.extend(event_results)
 
     db.commit()
+    debug_recorder.save_step_io(
+        "segment_pipeline",
+        input_data={"segment_count": len(seg_results)},
+        output_data={
+            "total_event_count": len(all_event_results),
+            "segments": segment_debug_summaries,
+        },
+    )
     logger.info("イベント生成完了: %d 件", len(all_event_results))
 
     # ── 発話計画 ──────────────────────────────────────────────────────────────
     planner = UtterancePlanner()
     plan_results = planner.plan(str(video.id), all_event_results)
+    debug_recorder.save_step_io(
+        "planning",
+        input_data={"event_count": len(all_event_results)},
+        output_data={
+            "plan_count": len(plan_results),
+            "plans": [
+                {
+                    "plan_id": pr.plan_id,
+                    "event_ids": pr.event_ids,
+                    "start_time": pr.start_time,
+                    "end_time": pr.end_time,
+                    "priority": pr.priority,
+                    "style": pr.style,
+                }
+                for pr in plan_results
+            ],
+        },
+    )
     logger.info("発話計画: %d 件", len(plan_results))
 
     # ── LLM 実況生成 ──────────────────────────────────────────────────────────
@@ -156,8 +317,9 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
     )
     commentary_service = CommentaryService()
     prev_text = ""
+    commentary_debug_rows: list[dict[str, Any]] = []
 
-    for pr in plan_results:
+    for plan_idx, pr in enumerate(plan_results):
         plan = UtterancePlan(
             video_id=video.id,
             event_ids=pr.event_ids,
@@ -179,10 +341,28 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
             llm_raw_response=com_data["llm_raw_response"],
         )
         db.add(commentary)
+        commentary_debug_rows.append(
+            {
+                "index": plan_idx,
+                "plan_id": str(plan.id),
+                "event_ids": pr.event_ids,
+                "style": com_data["style"],
+                "text": com_data["text"],
+                "language": com_data["language"],
+            }
+        )
         prev_text = com_data["text"]
         logger.info("実況生成: [%s] %s", pr.style, com_data["text"][:40])
 
     db.commit()
+    debug_recorder.save_step_io(
+        "commentary_generation",
+        input_data={"plan_count": len(plan_results)},
+        output_data={
+            "commentary_count": len(commentary_debug_rows),
+            "commentaries": commentary_debug_rows,
+        },
+    )
 
     # ── TTS 音声生成 + 字幕生成 ──────────────────────────────────────────────
     tts_client = QwenTTSClient(
@@ -248,6 +428,15 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
         srt_paths.append(srt_result.file_path)
 
     db.commit()
+    debug_recorder.save_step_io(
+        "tts_and_subtitle",
+        input_data={"plan_count": len(plans_in_db)},
+        output_data={
+            "audio_count": len(audio_entries),
+            "subtitle_count": len(srt_paths),
+            "srt_paths": srt_paths,
+        },
+    )
     logger.info("音声・字幕生成完了: %d 件", len(audio_entries))
 
     # ── 動画合成 ──────────────────────────────────────────────────────────────
@@ -255,6 +444,15 @@ def _run_pipeline(db: Session, input_path: str, title: str) -> str:
     output_path = str(media_dir / "output.mp4")
     composer = Composer(media_root=settings.media_root)
     composer.compose(str(dest_path), audio_entries, merged_srt, output_path)
+    debug_recorder.save_step_io(
+        "compose",
+        input_data={
+            "input_video": str(dest_path),
+            "audio_count": len(audio_entries),
+            "merged_srt": merged_srt,
+        },
+        output_data={"output_path": output_path},
+    )
 
     logger.info("=== パイプライン完了: %s ===", output_path)
     return output_path

--- a/tests/test_core/test_pipeline_debug.py
+++ b/tests/test_core/test_pipeline_debug.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from app.utils.pipeline_debug import PipelineDebugRecorder
+
+
+@dataclass
+class _DummyObject:
+    label: str
+
+
+def test_save_step_io_with_dataclass_and_path_writes_json(tmp_path: Path) -> None:
+    recorder = PipelineDebugRecorder(str(tmp_path), "video-001")
+    output_path = recorder.save_step_io(
+        step_name="segment step",
+        input_data={
+            "obj": _DummyObject(label="ok"),
+            "path": tmp_path / "frames" / "frame_0001.jpg",
+        },
+        output_data={"result": "saved"},
+    )
+
+    assert output_path is not None
+    payload = json.loads(Path(output_path).read_text(encoding="utf-8"))
+    assert payload["video_id"] == "video-001"
+    assert payload["step"] == "segment step"
+    assert payload["input"]["obj"]["label"] == "ok"
+    assert payload["input"]["path"].endswith("frame_0001.jpg")
+    assert payload["output"]["result"] == "saved"
+
+
+def test_append_segment_debug_when_called_twice_appends_jsonl(tmp_path: Path) -> None:
+    recorder = PipelineDebugRecorder(str(tmp_path), "video-xyz")
+    log_path = recorder.append_segment_debug(
+        segment_index=0,
+        segment_id="seg-a",
+        stage="frame_extraction",
+        input_data={"start_time": 0.0},
+        output_data={"frame_count": 1},
+    )
+    recorder.append_segment_debug(
+        segment_index=0,
+        segment_id="seg-a",
+        stage="event_generation",
+        input_data={"analysis_count": 1},
+        output_data={"event_count": 2},
+    )
+
+    assert log_path is not None
+    lines = Path(log_path).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    first_payload = json.loads(lines[0])
+    second_payload = json.loads(lines[1])
+    assert first_payload["stage"] == "frame_extraction"
+    assert first_payload["output"]["frame_count"] == 1
+    assert second_payload["stage"] == "event_generation"
+    assert second_payload["output"]["event_count"] == 2


### PR DESCRIPTION
## 概要
- `process` / `compose` API と `scripts/run_pipeline.py` に、ステップ入出力保存（JSON）と segment 単位デバッグログ（JSONL）を追加
- `PipelineDebugRecorder` を新規追加し、ログ保存処理を共通化
- `PipelineDebugRecorder` の単体テストを追加
- 実行環境の明確化として、`AGENTS.md` と `ship` / `test-check` スキルを `.venv/bin/...` 実行前提に更新

## 関連 Issue
Closes #22

## 確認事項
- [ ] 正常系確認
- [ ] 異常系確認
- [x] テスト追加（該当時）
- [x] pre-commit 通過
