### PR TITLE
chore: add long-run autopilot workflow and codex hooks

### DIFF
--- a/.claude/skills/long-run/SKILL.md
+++ b/.claude/skills/long-run/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: long-run
+description: 長時間作業を中断せず、自走専用ブランチで継続し最後に main へ統合する
+---
+
+# skill: long-run
+
+長時間の実装・調査タスクを、不要な確認待ちを挟まずに継続実行する。
+作業は `main` 直下で行わず、自走専用ブランチを親にして進める。
+
+## 使い方
+
+```
+/long-run <作業内容>
+例: /long-run #21 パフォーマンス検証を最後まで進める
+```
+
+## 実行前提
+
+- このスキルは Full Access 前提で実行する
+- 明示的な停止指示があるまで、実装・検証・修正を継続する
+- マイルストーンごとに進捗は共有するが、「続けてよいか」の確認は原則しない
+- 判断が必要な箇所は、影響が小さい側に倒して前進する
+
+## ブランチ運用（必須）
+
+1. `main` から自走専用の親ブランチを作る
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b autopilot/<topic>
+   ```
+2. 各実装は親ブランチから子ブランチを切って進める
+   ```bash
+   git checkout autopilot/<topic>
+   git checkout -b feature/<task-slug>
+   ```
+3. 子ブランチで実装・検証後、親ブランチへマージする
+   ```bash
+   git checkout autopilot/<topic>
+   git merge --no-ff feature/<task-slug>
+   ```
+4. すべて完了したら `autopilot/<topic>` から `main` へ PR を作る
+5. `main` への最終 PR まで、作業途中の子ブランチは `main` に直接 PR しない
+
+## 実行手順
+
+0. 目的と完了条件を 1〜3 行で再確認する
+1. 自走専用親ブランチ `autopilot/<topic>` を用意する
+2. 影響範囲を調査し、子ブランチを切って最短で価値が出る順に実装する
+3. 実装したら `.venv/bin/pre-commit run --all-files` と必要テストを実行する
+4. 失敗時は自己修正して再実行し、通るまで繰り返す
+5. 子ブランチを親へ順次マージし、最後に親ブランチから `main` へ PR を作成する
+6. 完了条件を満たしたら結果・未解決事項・次の推奨アクションを報告する
+
+## デフォルト前提
+
+- Python 系コマンドは `.venv/bin/...` を使う
+- 変更は最小差分で行い、不要なリファクタは混ぜない
+- 関連テストを優先し、必要に応じて `tests/test_core` など範囲を広げる
+
+## Codex Hooks（Discord 通知）
+
+- Git hooks ではなく Codex hooks として通知を送る
+- `DISCORD_WEBHOOK_URL` を設定し、以下を実行する
+  ```bash
+  .venv/bin/python scripts/codex_hooks/notify_discord.py \
+    --event start --title "long-run 開始" --body "<作業内容>"
+  ```
+- 推奨イベント:
+  - `start`: 作業開始
+  - `checkpoint`: 中間マイルストーン
+  - `blocked`: ブロック発生
+  - `done`: 完了
+
+## ブロック時の動き
+
+- 10 分以上進捗が止まる場合は、代替案で前進できる道を先に試す
+- 必要なら `blocked` イベントを Discord に送信する
+- それでも解消しない場合のみ、質問は 1 回・短文で行う
+
+## 実行後の改善確認（必須）
+
+スキル実行の最後に、次を必ず人間へ確認する。
+
+1. 今回の進め方の感想（良かった点）
+2. 使いにくかった点・迷った点（使い勝手）
+3. エージェントからの改善提案（手順 / コマンド / 出力）
+4. このスキルを今すぐ更新するか（Yes / No）
+
+### 遷移ルール
+
+- Yes: `/update-skill long-run` を実行し、改善案を提示して承認後に反映する
+- No: 更新見送り理由を 1 行で記録し、次回見直しの条件を確認する
+- 関連 Issue がある場合: 確認結果（更新した / 見送った理由）を Issue コメントで共有する

--- a/.codex/hooks/README.md
+++ b/.codex/hooks/README.md
@@ -1,0 +1,26 @@
+# Codex Hooks
+
+Git hooks ではなく、Codex 作業フローから明示的に呼び出す通知フック。
+
+## 事前設定
+
+```bash
+export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+chmod +x .codex/hooks/notify_discord.sh
+```
+
+## 使い方
+
+```bash
+.codex/hooks/notify_discord.sh start "long-run 開始" "Issue #21 パフォーマンス検証"
+.codex/hooks/notify_discord.sh checkpoint "中間報告" "計測完了・分析中" 21
+.codex/hooks/notify_discord.sh blocked "要対応" "外部API待ちで停止" 21
+.codex/hooks/notify_discord.sh done "完了" "PR作成まで完了" 21
+```
+
+引数:
+- 第1引数: event (`start` / `checkpoint` / `blocked` / `done` / `error`)
+- 第2引数: title
+- 第3引数: body（任意）
+- 第4引数: issue 番号（任意）
+- 第5引数: branch 名（任意）

--- a/.codex/hooks/notify_discord.sh
+++ b/.codex/hooks/notify_discord.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT="${1:-checkpoint}"
+TITLE="${2:-Codex Hook}"
+BODY="${3:-}"
+ISSUE="${4:-}"
+BRANCH="${5:-}"
+
+.venv/bin/python scripts/codex_hooks/notify_discord.py \
+  --event "${EVENT}" \
+  --title "${TITLE}" \
+  --body "${BODY}" \
+  --issue "${ISSUE}" \
+  --branch "${BRANCH}"

--- a/.codex/skills/long-run/SKILL.md
+++ b/.codex/skills/long-run/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: long-run
+description: 長時間作業を中断せず、自走専用ブランチで継続し最後に main へ統合する
+---
+
+# skill: long-run
+
+長時間の実装・調査タスクを、不要な確認待ちを挟まずに継続実行する。
+作業は `main` 直下で行わず、自走専用ブランチを親にして進める。
+
+## 使い方
+
+```
+/long-run <作業内容>
+例: /long-run #21 パフォーマンス検証を最後まで進める
+```
+
+## 実行前提
+
+- このスキルは Full Access 前提で実行する
+- 明示的な停止指示があるまで、実装・検証・修正を継続する
+- マイルストーンごとに進捗は共有するが、「続けてよいか」の確認は原則しない
+- 判断が必要な箇所は、影響が小さい側に倒して前進する
+
+## ブランチ運用（必須）
+
+1. `main` から自走専用の親ブランチを作る
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b autopilot/<topic>
+   ```
+2. 各実装は親ブランチから子ブランチを切って進める
+   ```bash
+   git checkout autopilot/<topic>
+   git checkout -b feature/<task-slug>
+   ```
+3. 子ブランチで実装・検証後、親ブランチへマージする
+   ```bash
+   git checkout autopilot/<topic>
+   git merge --no-ff feature/<task-slug>
+   ```
+4. すべて完了したら `autopilot/<topic>` から `main` へ PR を作る
+5. `main` への最終 PR まで、作業途中の子ブランチは `main` に直接 PR しない
+
+## 実行手順
+
+0. 目的と完了条件を 1〜3 行で再確認する
+1. 自走専用親ブランチ `autopilot/<topic>` を用意する
+2. 影響範囲を調査し、子ブランチを切って最短で価値が出る順に実装する
+3. 実装したら `.venv/bin/pre-commit run --all-files` と必要テストを実行する
+4. 失敗時は自己修正して再実行し、通るまで繰り返す
+5. 子ブランチを親へ順次マージし、最後に親ブランチから `main` へ PR を作成する
+6. 完了条件を満たしたら結果・未解決事項・次の推奨アクションを報告する
+
+## デフォルト前提
+
+- Python 系コマンドは `.venv/bin/...` を使う
+- 変更は最小差分で行い、不要なリファクタは混ぜない
+- 関連テストを優先し、必要に応じて `tests/test_core` など範囲を広げる
+
+## Codex Hooks（Discord 通知）
+
+- Git hooks ではなく Codex hooks として通知を送る
+- `DISCORD_WEBHOOK_URL` を設定し、以下を実行する
+  ```bash
+  .venv/bin/python scripts/codex_hooks/notify_discord.py \
+    --event start --title "long-run 開始" --body "<作業内容>"
+  ```
+- 推奨イベント:
+  - `start`: 作業開始
+  - `checkpoint`: 中間マイルストーン
+  - `blocked`: ブロック発生
+  - `done`: 完了
+
+## ブロック時の動き
+
+- 10 分以上進捗が止まる場合は、代替案で前進できる道を先に試す
+- 必要なら `blocked` イベントを Discord に送信する
+- それでも解消しない場合のみ、質問は 1 回・短文で行う
+
+## 実行後の改善確認（必須）
+
+スキル実行の最後に、次を必ず人間へ確認する。
+
+1. 今回の進め方の感想（良かった点）
+2. 使いにくかった点・迷った点（使い勝手）
+3. エージェントからの改善提案（手順 / コマンド / 出力）
+4. このスキルを今すぐ更新するか（Yes / No）
+
+### 遷移ルール
+
+- Yes: `/update-skill long-run` を実行し、改善案を提示して承認後に反映する
+- No: 更新見送り理由を 1 行で記録し、次回見直しの条件を確認する
+- 関連 Issue がある場合: 確認結果（更新した / 見送った理由）を Issue コメントで共有する

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,13 +154,14 @@ mp4 入力
 - `sample_data/videos/` の mp4 はコミットしない
 - DB マイグレーションは自動生成後に内容確認してからコミットする
 - `app/core/` に外部 API 呼び出しを追加しない（`app/clients/` に実装する）
+- Discord 通知は Git hooks ではなく Codex hooks（`.codex/hooks/`）を使う
 
 ---
 
 ## Skills
 
 共通スキル:
-- `start` / `ship` / `sync-main` / `new-feature`
+- `start` / `ship` / `sync-main` / `new-feature` / `long-run`
 - `create-issue` / `update-skill`
 - `review` / `py-review` / `test-check`
 

--- a/docs/05_git/git_strategy.md
+++ b/docs/05_git/git_strategy.md
@@ -96,6 +96,33 @@ test: EventServiceの異常系テストを追加
 
 ---
 
+## 自走専用フロー（long-run）
+
+長時間作業は、`main` へ直接積まずに自走専用ブランチへ集約する。
+
+```text
+main
+└─ autopilot/<topic>          ← 自走専用親ブランチ
+   ├─ feature/<task-a>        ← 子ブランチA
+   ├─ fix/<task-b>            ← 子ブランチB
+   └─ ...
+```
+
+### 手順
+
+1. `main` から `autopilot/<topic>` を作成
+2. 子ブランチを `autopilot/<topic>` から作成して実装
+3. 子ブランチを `autopilot/<topic>` に順次マージ
+4. すべて完了後に `autopilot/<topic>` から `main` へ PR
+
+### ポイント
+
+- 作業途中の子ブランチは `main` に直接 PR しない
+- 最終的なレビュー単位は `autopilot/<topic> -> main` の1本にまとめる
+- 進捗通知は Git hooks ではなく Codex hooks（Discord 通知）を使う
+
+---
+
 ## タグ・リリース
 
 | タグ形式 | タイミング |

--- a/scripts/codex_hooks/notify_discord.py
+++ b/scripts/codex_hooks/notify_discord.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Codex hook 用 Discord 通知")
+    parser.add_argument(
+        "--event",
+        required=True,
+        choices=["start", "checkpoint", "blocked", "done", "error"],
+        help="通知イベント種別",
+    )
+    parser.add_argument("--title", required=True, help="通知タイトル")
+    parser.add_argument("--body", default="", help="通知本文")
+    parser.add_argument("--issue", default="", help="Issue 番号（例: 21）")
+    parser.add_argument("--branch", default="", help="ブランチ名（省略時は現在ブランチ）")
+    parser.add_argument("--strict", action="store_true", help="通知失敗時に非0で終了")
+    return parser.parse_args()
+
+
+def current_branch() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def build_payload(
+    event: str,
+    title: str,
+    body: str,
+    issue: str,
+    branch: str,
+) -> dict[str, str]:
+    emoji_map = {
+        "start": "🚀",
+        "checkpoint": "📍",
+        "blocked": "⚠️",
+        "done": "✅",
+        "error": "❌",
+    }
+    branch_value = branch or current_branch() or "(unknown)"
+    issue_line = f"Issue: #{issue}" if issue else "Issue: (none)"
+    lines = [
+        f"{emoji_map.get(event, 'ℹ️')} **{title}**",
+        f"Event: `{event}`",
+        f"Branch: `{branch_value}`",
+        issue_line,
+        f"Time: {datetime.now(tz=UTC).isoformat()}",
+    ]
+    if body:
+        lines.append("")
+        lines.append(body)
+    return {"content": "\n".join(lines)}
+
+
+def send_discord(webhook_url: str, payload: dict[str, str]) -> None:
+    req = urllib.request.Request(
+        webhook_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:
+        if response.status >= 300:
+            raise RuntimeError(f"Discord webhook failed: HTTP {response.status}")
+
+
+def main() -> int:
+    args = parse_args()
+    webhook = os.getenv("DISCORD_WEBHOOK_URL", "").strip()
+    if not webhook:
+        print("DISCORD_WEBHOOK_URL が未設定のため通知をスキップします。", file=sys.stderr)
+        return 1 if args.strict else 0
+
+    payload = build_payload(
+        event=args.event,
+        title=args.title,
+        body=args.body,
+        issue=args.issue,
+        branch=args.branch,
+    )
+
+    try:
+        send_discord(webhook, payload)
+    except (urllib.error.URLError, urllib.error.HTTPError, RuntimeError) as e:
+        print(f"Discord 通知失敗: {e}", file=sys.stderr)
+        return 1 if args.strict else 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要
- `long-run` スキルを自走専用親ブランチ（`autopilot/<topic>`）運用に更新
- Git hooks ではなく Codex hooks で Discord 通知する方針を明文化
- Codex hooks 用の Discord 通知スクリプトとラッパーを追加
- Git 戦略 / AGENTS に上記運用を追記

## 関連 Issue
N/A

## 確認事項
- [x] 正常系確認
- [ ] 異常系確認
- [ ] テスト追加（該当時）
- [x] pre-commit 通過
