### PR TITLE
fix: stabilize codex discord hook delivery

### DIFF
--- a/.codex/hooks/README.md
+++ b/.codex/hooks/README.md
@@ -5,9 +5,24 @@ Git hooks ではなく、Codex 作業フローから明示的に呼び出す通�
 ## 事前設定
 
 ```bash
+# 推奨: ローカル専用設定（Git 管理外）
+cat > .codex/hooks/.env.local <<'EOF'
+DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+EOF
+chmod 600 .codex/hooks/.env.local
+
+# 代替: 環境変数
 export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
 chmod +x .codex/hooks/notify_discord.sh
 ```
+
+`notify_discord.sh` は次の順序で webhook URL を解決する:
+1. `.codex/hooks/.env.local`
+2. 環境変数 `DISCORD_WEBHOOK_URL`
+3. `~/.bashrc` の `export DISCORD_WEBHOOK_URL=...`
+
+デフォルトで strict モード（送信失敗時に非0終了）で動作する。
+失敗を無視したい場合のみ `DISCORD_NOTIFY_STRICT=0` を設定する。
 
 ## 使い方
 

--- a/.codex/hooks/notify_discord.sh
+++ b/.codex/hooks/notify_discord.sh
@@ -1,15 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LOCAL_ENV_FILE="${SCRIPT_DIR}/.env.local"
+
+# 優先してローカル設定ファイルを読む（Git 管理外）
+if [[ -f "${LOCAL_ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  source "${LOCAL_ENV_FILE}"
+  set +a
+fi
+
+# フォールバック: ~/.bashrc の export を読む
+if [[ -z "${DISCORD_WEBHOOK_URL:-}" && -f "${HOME}/.bashrc" ]]; then
+  DISCORD_WEBHOOK_URL="$(
+    sed -n 's/^export DISCORD_WEBHOOK_URL="\([^"]*\)"/\1/p' "${HOME}/.bashrc" \
+      | tail -n 1
+  )"
+  export DISCORD_WEBHOOK_URL
+fi
+
 EVENT="${1:-checkpoint}"
 TITLE="${2:-Codex Hook}"
 BODY="${3:-}"
 ISSUE="${4:-}"
 BRANCH="${5:-}"
+STRICT_MODE="${DISCORD_NOTIFY_STRICT:-1}"
+STRICT_ARGS=()
+if [[ "${STRICT_MODE}" != "0" ]]; then
+  STRICT_ARGS=(--strict)
+fi
 
-.venv/bin/python scripts/codex_hooks/notify_discord.py \
+"${REPO_ROOT}/.venv/bin/python" "${REPO_ROOT}/scripts/codex_hooks/notify_discord.py" \
   --event "${EVENT}" \
   --title "${TITLE}" \
   --body "${BODY}" \
   --issue "${ISSUE}" \
-  --branch "${BRANCH}"
+  --branch "${BRANCH}" \
+  "${STRICT_ARGS[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ env/
 # Environment
 .env
 .env.local
+.codex/hooks/.env.local
 
 # IDE
 .vscode/

--- a/scripts/codex_hooks/notify_discord.py
+++ b/scripts/codex_hooks/notify_discord.py
@@ -73,7 +73,10 @@ def send_discord(webhook_url: str, payload: dict[str, str]) -> None:
     req = urllib.request.Request(
         webhook_url,
         data=json.dumps(payload).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "aituber-codex-hook/1.0",
+        },
         method="POST",
     )
     with urllib.request.urlopen(req, timeout=10) as response:


### PR DESCRIPTION
## 概要
- Codex Discord hook が `.codex/hooks/.env.local` を優先して読み込むように変更
- `~/.bashrc` の `DISCORD_WEBHOOK_URL` もフォールバック読込できるように変更
- Discord 送信の `urllib` リクエストに `User-Agent` を追加し、Cloudflare 403(1010) を回避
- `.codex/hooks/.env.local` を `.gitignore` に追加
- hooks README に永続化手順と strict モード挙動を追記

## 関連 Issue
N/A（関連Issueなし）

## 確認事項
- [x] 正常系確認
- [x] 異常系確認
- [ ] テスト追加（該当時）
- [x] pre-commit 通過
