### PR TITLE
fix: handle invalid video IDs and emit process performance logs

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -49,6 +49,7 @@ from app.models.models import (
 from app.models.schemas import TimelineItem, VideoRead, VideoTagRead, VideoTimeline, VideoUpdate
 from app.utils.logging import logger
 from app.utils.pipeline_debug import PipelineDebugRecorder
+from app.utils.pipeline_performance import PipelinePerformanceRecorder
 from app.utils.pipeline_state import PipelineSegmentStateStore
 
 router = APIRouter()
@@ -143,9 +144,7 @@ def delete_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     Returns:
         削除結果 (`status`, `video_id`) を含む辞書。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
 
     media_dir = Path(settings.media_root) / str(video.id)
     try:
@@ -178,9 +177,7 @@ def get_video(video_id: str, db: Session = Depends(get_db)) -> VideoRead:
     Returns:
         対象動画の詳細情報。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
     return _to_video_read(video)
 
 
@@ -195,9 +192,7 @@ def get_video_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTagRead
     Returns:
         手動タグ・自動タグ・有効タグとタグソースをまとめたレスポンス。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
     return _to_video_tag_read(video.video_metadata)
 
 
@@ -213,9 +208,7 @@ def update_video(video_id: str, payload: VideoUpdate, db: Session = Depends(get_
     Returns:
         更新後の動画情報。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
 
     if payload.title is not None:
         new_title = payload.title.strip()
@@ -252,9 +245,7 @@ def refresh_video_rule_tags(video_id: str, db: Session = Depends(get_db)) -> Vid
     Returns:
         更新後タグ情報。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
 
     cfg = get_runtime_settings(db)
     metadata = _refresh_rule_tags(video, cfg)
@@ -283,9 +274,7 @@ def refresh_video_llm_tags(video_id: str, db: Session = Depends(get_db)) -> Vide
     Returns:
         更新後タグ情報。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
 
     cfg = get_runtime_settings(db)
     llm_client = LLMClient(
@@ -324,9 +313,7 @@ def refresh_video_tags(video_id: str, db: Session = Depends(get_db)) -> VideoTag
     Returns:
         ルール・LLM 両方の更新を反映したタグ情報。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
 
     cfg = get_runtime_settings(db)
     llm_client = LLMClient(
@@ -366,9 +353,7 @@ def get_timeline(video_id: str, db: Session = Depends(get_db)) -> VideoTimeline:
     Returns:
         入力動画相対パスと実況タイムライン項目の集合。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
 
     storage = Path(video.storage_path)
     media_root = Path(settings.media_root)
@@ -379,7 +364,7 @@ def get_timeline(video_id: str, db: Session = Depends(get_db)) -> VideoTimeline:
 
     plans = (
         db.query(UtterancePlan)
-        .filter(UtterancePlan.video_id == video_id)
+        .filter(UtterancePlan.video_id == video.id)
         .order_by(UtterancePlan.start_time)
         .all()
     )
@@ -421,12 +406,16 @@ def process_video(
     Returns:
         実行結果サマリー。処理済み/再利用/失敗セグメント番号を含む。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
+    current_video_id = str(video.id)
 
     cfg = get_runtime_settings(db)
     debug_recorder = PipelineDebugRecorder(cfg.media_root, str(video.id))
+    perf_recorder = PipelinePerformanceRecorder(cfg.media_root, str(video.id))
+    perf_recorder.checkpoint(
+        "process_started",
+        payload={"video_id": current_video_id, "rerun_failed_only": rerun_failed_only},
+    )
     state_store = PipelineSegmentStateStore(cfg.media_root, str(video.id))
     llm_client = LLMClient(
         base_url=cfg.llm_api_base,
@@ -453,6 +442,10 @@ def process_video(
         },
         output_data={"video_metadata": metadata},
     )
+    perf_recorder.checkpoint(
+        "tag_refresh_done",
+        payload={"tag_status": metadata.get("tag_status", {})},
+    )
 
     seg_service = SegmentationService(
         segment_duration=cfg.segment_duration,
@@ -475,15 +468,19 @@ def process_video(
         max_queue_delay_seconds=cfg.planner_max_queue_delay_seconds,
     )
     commentary_service = CommentaryService()
-    update_progress(video_id, "segmentation", 0, "動画を分割中...")
+    update_progress(current_video_id, "segmentation", 0, "動画を分割中...")
     try:
         seg_results = seg_service.execute(video.storage_path, str(video.id))
     except subprocess.CalledProcessError as e:
         stderr = e.stderr.decode(errors="replace") if e.stderr else ""
         logger.error("FFmpeg 分割失敗: %s", stderr)
+        perf_recorder.finalize(
+            {"status": "error", "stage": "segmentation", "error": f"ffmpeg: {stderr[:200]}"}
+        )
         raise HTTPException(status_code=500, detail=f"FFmpeg エラー: {stderr[:500]}") from e
     except Exception as e:
         logger.error("process エラー: %s", e)
+        perf_recorder.finalize({"status": "error", "stage": "segmentation", "error": str(e)})
         raise HTTPException(status_code=500, detail=str(e)) from e
 
     state_store.sync_segments(seg_results)
@@ -518,7 +515,13 @@ def process_video(
             ],
         },
     )
-    update_progress(video_id, "segmentation", 10, f"分割完了: {len(seg_results)} セグメント")
+    perf_recorder.checkpoint(
+        "segmentation_done",
+        payload={"segment_count": len(seg_results)},
+    )
+    update_progress(
+        current_video_id, "segmentation", 10, f"分割完了: {len(seg_results)} セグメント"
+    )
 
     if not rerun_failed_only:
         removed_segments = (
@@ -532,7 +535,7 @@ def process_video(
         db.commit()
         logger.info(
             "既存処理結果を初期化: video_id=%s removed_segments=%d removed_plans=%d",
-            video_id,
+            current_video_id,
             removed_segments,
             removed_plans,
         )
@@ -547,7 +550,7 @@ def process_video(
     for seg_idx, seg_result in enumerate(seg_results):
         logger.debug(
             "segment処理開始: video_id=%s index=%d/%d range=%.2f-%.2f",
-            video_id,
+            current_video_id,
             seg_idx + 1,
             seg_count,
             seg_result.start_time,
@@ -604,7 +607,7 @@ def process_video(
         if rerun_failed_only and not should_reprocess and existing_segment is None:
             logger.info(
                 "再利用対象セグメントの既存データがないため再処理へ切替: video_id=%s index=%d",
-                video_id,
+                current_video_id,
                 seg_idx,
             )
 
@@ -692,7 +695,10 @@ def process_video(
 
                 pct = 10 + int((seg_idx + 1) / seg_count * 60)
                 update_progress(
-                    video_id, "vision", pct, f"フレーム解析中: {seg_idx + 1}/{seg_count}"
+                    current_video_id,
+                    "vision",
+                    pct,
+                    f"フレーム解析中: {seg_idx + 1}/{seg_count}",
                 )
 
                 event_results = event_service.generate(
@@ -755,7 +761,7 @@ def process_video(
             )
             logger.debug(
                 "segment処理完了: video_id=%s segment_id=%s frames=%d events=%d",
-                video_id,
+                current_video_id,
                 segment.id,
                 len(frame_results),
                 len(event_results),
@@ -763,7 +769,7 @@ def process_video(
         except Exception as e:
             logger.error(
                 "segment処理失敗: video_id=%s index=%d error=%s",
-                video_id,
+                current_video_id,
                 seg_idx,
                 e,
             )
@@ -791,14 +797,14 @@ def process_video(
     db.commit()
     logger.info(
         "発話計画再生成のため既存 plan を削除: video_id=%s removed_plans=%d",
-        video_id,
+        current_video_id,
         removed_plans_for_rebuild,
     )
 
     if failed_segment_indexes:
         logger.warning(
             "segment処理で失敗を検知: video_id=%s failed_indexes=%s",
-            video_id,
+            current_video_id,
             sorted(failed_segment_indexes),
         )
 
@@ -816,7 +822,16 @@ def process_video(
             "segments": segment_debug_summaries,
         },
     )
-    update_progress(video_id, "planning", 75, "発話計画を生成中...")
+    perf_recorder.checkpoint(
+        "segment_pipeline_done",
+        payload={
+            "processed_count": len(processed_segment_indexes),
+            "reused_count": len(reused_segment_indexes),
+            "failed_count": len(failed_segment_indexes),
+            "event_count": len(all_events),
+        },
+    )
+    update_progress(current_video_id, "planning", 75, "発話計画を生成中...")
 
     plan_results = planner.plan(str(video.id), all_events)
     debug_recorder.save_step_io(
@@ -837,7 +852,11 @@ def process_video(
             ],
         },
     )
-    update_progress(video_id, "planning", 80, f"発話計画完了: {len(plan_results)} 件")
+    perf_recorder.checkpoint(
+        "planning_done",
+        payload={"plan_count": len(plan_results)},
+    )
+    update_progress(current_video_id, "planning", 80, f"発話計画完了: {len(plan_results)} 件")
     prev_text = ""
     plan_count = len(plan_results)
     commentary_debug_rows: list[dict[str, Any]] = []
@@ -875,7 +894,12 @@ def process_video(
         )
         if plan_count > 0:
             pct = 80 + int((plan_idx + 1) / plan_count * 15)
-            update_progress(video_id, "commentary", pct, f"実況生成中: {plan_idx + 1}/{plan_count}")
+            update_progress(
+                current_video_id,
+                "commentary",
+                pct,
+                f"実況生成中: {plan_idx + 1}/{plan_count}",
+            )
         prev_text = com_data["text"]
 
     db.commit()
@@ -887,15 +911,32 @@ def process_video(
             "commentaries": commentary_debug_rows,
         },
     )
-    update_progress(video_id, "done", 100, "処理完了")
+    perf_recorder.finalize(
+        {
+            "status": "ok",
+            "video_id": current_video_id,
+            "segment_count": len(seg_results),
+            "event_count": len(all_events),
+            "plan_count": len(plan_results),
+            "processed_count": len(processed_segment_indexes),
+            "reused_count": len(reused_segment_indexes),
+            "failed_count": len(failed_segment_indexes),
+            "rerun_failed_only": rerun_failed_only,
+        }
+    )
+    update_progress(current_video_id, "done", 100, "処理完了")
+    performance_log_path = str(
+        Path(cfg.media_root) / current_video_id / "debug" / "performance.json"
+    )
     result = {
         "status": "ok",
-        "video_id": video_id,
+        "video_id": current_video_id,
         "plans": len(plan_results),
         "rerun_failed_only": rerun_failed_only,
         "processed_segments": sorted(processed_segment_indexes),
         "reused_segments": sorted(reused_segment_indexes),
         "failed_segments": sorted(failed_segment_indexes),
+        "performance_log_path": performance_log_path,
     }
     debug_recorder.save_step_io(
         "process_result",
@@ -916,9 +957,8 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     Returns:
         出力動画のパスを含む結果辞書。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
+    current_video_id = str(video.id)
 
     cfg = get_runtime_settings(db)
     debug_recorder = PipelineDebugRecorder(cfg.media_root, str(video.id))
@@ -935,7 +975,7 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
 
     plans = (
         db.query(UtterancePlan)
-        .filter(UtterancePlan.video_id == video_id)
+        .filter(UtterancePlan.video_id == video.id)
         .order_by(UtterancePlan.start_time)
         .all()
     )
@@ -947,7 +987,7 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
     subtitle_debug_rows: list[dict[str, Any]] = []
     schedule_debug_rows: list[dict[str, Any]] = []
     plan_count = len(plans)
-    update_progress(video_id, "compose", 0, "音声合成を開始...")
+    update_progress(current_video_id, "compose", 0, "音声合成を開始...")
 
     try:
         for plan_idx, plan in enumerate(plans):
@@ -958,7 +998,9 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
                 continue
 
             pct = int((plan_idx + 1) / plan_count * 80)
-            update_progress(video_id, "tts", pct, f"音声合成中: {plan_idx + 1}/{plan_count}")
+            update_progress(
+                current_video_id, "tts", pct, f"音声合成中: {plan_idx + 1}/{plan_count}"
+            )
             audio_path = str(Path(cfg.media_root) / str(commentary.id) / "audio.wav")
             instruct = _STYLE_INSTRUCT.get(commentary.style or "", "")
             speaker = _resolve_tts_speaker(commentary.style or "", cfg)
@@ -1078,23 +1120,24 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
             },
         )
 
-        update_progress(video_id, "compose", 85, "字幕・動画を合成準備中...")
-        update_progress(video_id, "compose", 88, "字幕ファイルを結合中...")
-        merged_srt = _merge_srt(srt_paths, video_id, cfg.media_root)
-        update_progress(video_id, "compose", 92, "映像・音声を合成中（FFmpeg）...")
-        output_path = str(Path(cfg.media_root) / str(video_id) / "output.mp4")
+        update_progress(current_video_id, "compose", 85, "字幕・動画を合成準備中...")
+        update_progress(current_video_id, "compose", 88, "字幕ファイルを結合中...")
+        merged_srt = _merge_srt(srt_paths, current_video_id, cfg.media_root)
+        update_progress(current_video_id, "compose", 92, "映像・音声を合成中（FFmpeg）...")
+        output_path = str(Path(cfg.media_root) / current_video_id / "output.mp4")
         composer.compose(video.storage_path, audio_entries, merged_srt, output_path)
         debug_recorder.save_step_io(
             "compose",
             input_data={
                 "video_id": video_id,
+                "video_id_normalized": current_video_id,
                 "input_video": video.storage_path,
                 "audio_count": len(audio_entries),
                 "merged_srt": merged_srt,
             },
             output_data={"output_path": output_path},
         )
-        update_progress(video_id, "compose", 98, "最終処理中...")
+        update_progress(current_video_id, "compose", 98, "最終処理中...")
 
     except subprocess.CalledProcessError as e:
         stderr = e.stderr.decode(errors="replace") if e.stderr else ""
@@ -1105,7 +1148,7 @@ def compose_video(video_id: str, db: Session = Depends(get_db)) -> dict:
         raise HTTPException(status_code=500, detail=str(e)) from e
 
     logger.info("合成完了: %s", output_path)
-    update_progress(video_id, "done", 100, "合成完了")
+    update_progress(current_video_id, "done", 100, "合成完了")
     return {"status": "ok", "output_path": output_path}
 
 
@@ -1127,13 +1170,12 @@ def export_video(video_id: str, db: Session = Depends(get_db)) -> StreamingRespo
     Returns:
         ZIP ファイルを返すストリーミングレスポンス。
     """
-    video = db.query(Video).filter(Video.id == video_id).first()
-    if not video:
-        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    video = _get_video_or_404(db, video_id)
+    current_video_id = str(video.id)
 
     plans = (
         db.query(UtterancePlan)
-        .filter(UtterancePlan.video_id == video_id)
+        .filter(UtterancePlan.video_id == video.id)
         .order_by(UtterancePlan.start_time)
         .all()
     )
@@ -1211,13 +1253,51 @@ def export_video(video_id: str, db: Session = Depends(get_db)) -> StreamingRespo
         zf.writestr("timeline.exo", exo_bytes)
 
     buf.seek(0)
-    filename = f"aituber_export_{video_id[:8]}.zip"
+    filename = f"aituber_export_{current_video_id[:8]}.zip"
     logger.info("エクスポート: %s (%d 発話)", filename, len(csv_rows))
     return StreamingResponse(
         buf,
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+def _parse_video_uuid(video_id: str) -> uuid.UUID:
+    """動画ID文字列をUUIDへ変換する。
+
+    Args:
+        video_id: パスパラメータで受け取った動画ID文字列。
+
+    Returns:
+        正常に変換された `UUID` オブジェクト。
+
+    Raises:
+        HTTPException: UUID形式でない場合。
+    """
+    try:
+        return uuid.UUID(video_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail="動画が見つかりません") from e
+
+
+def _get_video_or_404(db: Session, video_id: str) -> Video:
+    """動画IDから動画レコードを取得し、未存在時は404を送出する。
+
+    Args:
+        db: 動画取得に利用する DB セッション。
+        video_id: 文字列形式の動画ID。
+
+    Returns:
+        取得した `Video` モデル。
+
+    Raises:
+        HTTPException: 動画ID形式が不正、または動画が存在しない場合。
+    """
+    parsed_video_id = _parse_video_uuid(video_id)
+    video = db.query(Video).filter(Video.id == parsed_video_id).first()
+    if not video:
+        raise HTTPException(status_code=404, detail="動画が見つかりません")
+    return video
 
 
 def _find_segment_by_time(

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -15,20 +15,23 @@ export default function VideoDetailPage() {
   const { id } = useParams<{ id: string }>()
   const [tagInput, setTagInput] = useState('')
   const [tagSaving, setTagSaving] = useState(false)
-  const { data: video, isLoading } = useQuery({
+  const { data: video, isLoading, isError, error } = useQuery({
     queryKey: ['video', id],
     queryFn: () => getVideo(id!),
     enabled: !!id,
+    retry: false,
   })
   const { data: tagInfo, refetch: refetchTags } = useQuery({
     queryKey: ['video-tags', id],
     queryFn: () => getVideoTags(id!),
     enabled: !!id,
+    retry: false,
   })
   const { data: timeline, refetch: refetchTimeline } = useQuery({
     queryKey: ['timeline', id],
     queryFn: () => getTimeline(id!),
     enabled: !!id,
+    retry: false,
   })
 
   const { progress: sseProgress, start } = useSSE(id ?? null)
@@ -75,6 +78,13 @@ export default function VideoDetailPage() {
   const failOp = () => setOpState('idle')
 
   if (isLoading) return <p className="text-gray-400">読み込み中...</p>
+  if (isError) {
+    const status = (error as { response?: { status?: number } } | null)?.response?.status
+    if (status === 404) {
+      return <p className="text-red-500">動画が見つかりません</p>
+    }
+    return <p className="text-red-500">動画の読み込みに失敗しました</p>
+  }
   if (!video) return <p className="text-red-500">動画が見つかりません</p>
 
   const inputSrc = timeline?.input_rel

--- a/tests/test_api/test_videos_id_validation.py
+++ b/tests/test_api/test_videos_id_validation.py
@@ -1,0 +1,71 @@
+"""videos API の動画ID検証ヘルパーを検証する。"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.videos import _get_video_or_404, _parse_video_uuid
+
+
+class _DummyQuery:
+    """テスト用の簡易 Query モック。"""
+
+    def __init__(self, result: object | None) -> None:
+        """返却結果を受け取って初期化する。"""
+        self._result = result
+
+    def filter(self, *_args: object, **_kwargs: object) -> _DummyQuery:
+        """filter 呼び出しを透過し、自身を返す。"""
+        return self
+
+    def first(self) -> object | None:
+        """first の戻り値として初期化時の結果を返す。"""
+        return self._result
+
+
+class _DummySession:
+    """テスト用の簡易 Session モック。"""
+
+    def __init__(self, result: object | None) -> None:
+        """query().first() で返す結果を保持する。"""
+        self._result = result
+
+    def query(self, _model: object) -> _DummyQuery:
+        """常に同じ結果を返す Query モックを返却する。"""
+        return _DummyQuery(self._result)
+
+
+def test_parse_video_uuid_when_valid_returns_uuid() -> None:
+    """有効UUID文字列を UUID オブジェクトへ変換できることを確認する。"""
+    video_id = "40dfddae-d7f8-4e55-847b-ac2279bbf07b"
+    parsed = _parse_video_uuid(video_id)
+    assert isinstance(parsed, uuid.UUID)
+    assert str(parsed) == video_id
+
+
+def test_parse_video_uuid_when_invalid_raises_404() -> None:
+    """不正文字列を 404 として扱うことを確認する。"""
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_video_uuid("not-a-uuid")
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "動画が見つかりません"
+
+
+def test_get_video_or_404_when_video_exists_returns_model() -> None:
+    """動画が存在する場合にそのまま返却されることを確認する。"""
+    video = object()
+    db = _DummySession(video)
+    resolved = _get_video_or_404(db, "40dfddae-d7f8-4e55-847b-ac2279bbf07b")
+    assert resolved is video
+
+
+def test_get_video_or_404_when_video_missing_raises_404() -> None:
+    """動画が存在しない場合に404を送出することを確認する。"""
+    db = _DummySession(None)
+    with pytest.raises(HTTPException) as exc_info:
+        _get_video_or_404(db, "40dfddae-d7f8-4e55-847b-ac2279bbf07b")
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "動画が見つかりません"


### PR DESCRIPTION
## 概要
- `#93` 対応: 動画IDの検証を共通化し、UUID不正/未存在時のレスポンスを404へ統一
- `#93` 対応: 詳細画面で動画取得エラーを明示表示し、無駄なリトライを抑制
- `#95` 対応: `process` API 実行時に `PipelinePerformanceRecorder` で `performance.json` を生成
- `#95` 対応: `process` レスポンスに `performance_log_path` を追加し、参照導線を明確化
- APIヘルパーの単体テストを新規追加

## 関連 Issue
- #93
- #95

## 確認
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/pytest tests/ -v --capture=no` (51 passed)
- [x] `.venv/bin/pre-commit run --all-files`

## 備考
- `npm --prefix frontend run build` は環境制約（WSL1）で実行不可
